### PR TITLE
feat: expand debate analysis with trust tracking and context tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS Guidelines
+
+## Purpose
+This file provides guidance for contributors and automated agents working in this repository. Follow these rules to keep the codebase reliable and easy to maintain.
+
+## Core Principles
+- **Reuse first**: search for existing modules before implementing new ones.
+- **Integrate fully**: every addition must connect to upstream and downstream workflows.
+- **Validate rigorously**: ensure changes are tested, documented, and reflected in the progress tracker.
+
+## Code Style
+- Target **Python 3.10+** and write clear, idiomatic code.
+- Adhere to [PEP 8](https://peps.python.org/pep-0008/) and include type hints and docstrings.
+- Keep functions small and focused; prefer composition over large monoliths.
+- Reuse existing modules in `src/ultimate_discord_intelligence_bot/tools/` instead of duplicating logic.
+- Avoid creating new top-level directories unless absolutely necessary.
+
+## Workflow Rules
+- Search the repo with `rg` (ripgrep) rather than `grep -R` or `ls -R`.
+- Run **`pytest`** after any code or documentation change.
+- Ensure the working tree is clean (`git status --short`) before finishing.
+- Commit using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:` …).
+- Do not rewrite history or create new branches; treat commits as append-only.
+
+## Contribution Template
+Follow this checklist whenever adding agents, tasks, tools, or workflows:
+1. **Define the Purpose** – explain the problem and how the piece fits the system. Extend existing logic rather than duplicating it.
+2. **File & Code Setup** – place files under the correct directories, update `config/agents.yaml`, `config/tasks.yaml`, and `crew.py`.
+3. **Integration Steps** – wire inputs/outputs so the new component connects to upstream and downstream steps. Register tools explicitly.
+4. **Testing & Validation** – add or update tests and run `pytest` to validate end‑to‑end behaviour.
+5. **Progress Tracking** – update this AGENTS.md progress tracker so contributors know what’s done and what’s pending.
+
+## Project Goals
+1. Build a debate-analysis system with partisan defenders (Traitor AB & Old Dan).
+2. Ingest videos and transcripts from multiple platforms (YouTube, Twitch, Kick, Twitter/X, Instagram, Discord).
+3. Verify clip context, fact‑check claims, and trace misinfo sources.
+4. Maintain persistent scores for lies, misquotes, misinfo, and trustworthiness.
+5. Store transcripts, analyses, and social context in Qdrant for retrieval.
+6. Deliver all monitoring and alerts through Discord.
+7. Provide Discord commands for analysis, context lookup, fact checking, leaderboard, profiles, timelines, and Q&A.
+
+## Deliverables
+- Multi-platform ingestion tools and monitoring agents.
+- Debate analysis pipeline with transcript indexing, context verification, fact checking, defender blurbs, and score updates.
+- Leaderboard, trust tracker, timeline, and profile tools with persistence.
+- Vector memory integration backed by Qdrant and Discord Q&A interface.
+- System alert manager and Discord command handlers for `/analyze`, `/context`, `/claim`, `/timeline`, `/profile`, `/leaderboard`, `/ask`, etc.
+- Comprehensive documentation and tests for all new components.
+
+## Progress Tracker
+### Completed
+- Debate analysis pipeline and Discord command tool.
+- Transcript indexing, context verification, fact checking, and scoreboard persistence.
+- Trustworthiness tracker and character profile manager.
+- Timeline tool and vector search-based Discord Q&A.
+- System alert manager for Discord-only monitoring.
+- Cross-platform intelligence gatherer agent.
+- Steelman argument generator.
+- Twitch, Kick, Twitter, Instagram downloaders and X/Discord monitor tools.
+- Qdrant collections separated for transcripts and analyses.
+
+### To Do
+- Add enhanced fact-checking backends (Serply, EXA, Perplexity, WolframAlpha).
+- Implement logical fallacy upgrades.
+- Add full workflow tests for new ingestion sources.
+- Document environment variables and deployment steps for new platforms.
+
+*Update this file whenever significant goals are finished or new tasks arise.*

--- a/README.md
+++ b/README.md
@@ -32,24 +32,45 @@ Key variables include `CREWAI_BASE_DIR` (defaulting to a `crew_data` folder in y
 home directory) and optional overrides like `CREWAI_DOWNLOADS_DIR` or
 `CREWAI_YTDLP_CONFIG` for custom locations. The repository ships with a default
 yt-dlp configuration under `yt-dlp/config/crewai-system.conf` and supports
-downloading from YouTube, Twitch, Kick and X/Twitter. The pipeline automatically
+downloading from YouTube, Twitch, Kick, Instagram and X/Twitter. The pipeline automatically
 selects the appropriate downloader based on the URL. When providing a Discord
 webhook via `DISCORD_WEBHOOK` ensure it is a public HTTPS URL; local or private
 IP addresses are rejected for safety. A separate `DISCORD_PRIVATE_WEBHOOK` can
 be supplied to the internal `Discord Private Alert Tool` for system health
-notifications. Pair this with the `System Status Tool` to include CPU load and
-disk usage metrics in those alerts.
+notifications. Pair this with the `System Status Tool` and the `monitor_system`
+task to include CPU load and disk usage metrics in those alerts.
 The accompanying `Multi-Platform Monitor Tool` keeps an in-memory record of
 seen items and reports only fresh content so downloads are triggered once per
-upload.
+upload. Dedicated monitors for X and Discord expose structured metadata for new
+posts, paving the way for richer context gathering.
 To broaden analysis beyond video content, the repository ships lightweight
 tools for gathering social-media chatter and scoring factual accuracy. The
 `Social Media Monitor Tool` aggregates Reddit, X and Discord posts matching a
 keyword, while the `Truth Scoring Tool` converts fact-check verdicts into a
-numerical trustworthiness score.
+numerical trustworthiness score.  Building on those verdicts, the
+`Trustworthiness Tracker Tool` maintains per-person counts of truthful and
+false statements to derive long-term reliability profiles that feed the
+overall scoreboard.  For clip context
+checks, the `Transcript Index Tool` slices transcripts into timestamped
+chunks so the `Context Verification Tool` can compare quoted clips against the
+surrounding transcript.  Claims can be probed via the lightweight `Fact Check
+Tool`, and cumulative lie or misquote counts are persisted by the
+`Leaderboard Tool`.  A `Steelman Argument Tool` combines supporting snippets to
+produce the strongest possible version of a claim for deep-dive reasoning.
+These pieces power the informal H3/Hasan debate analysis
+flow: VODs are indexed, clip context verified, claims fact-checked and a
+scoreboard of lies, misquotes and misinfo is exposed through Discord commands
+like `/analyze`, `/context`, `/claim`, `/leaderboard`, `/timeline` and `/ask`.
+Two partisan defenders – Traitor AB for Ethan and Old Dan for Hasan – generate
+short, casual closing statements for each analysis.  The `/timeline` command
+surfaces a chronological list of analysed clips for a video while `/ask`
+queries the stored vector memory to surface relevant transcript or analysis
+snippets for quick Q&A.  A `/profile` command summarises per-person trust
+metrics and recent events collected throughout debates.
 For long-term memory the pipeline can connect to a Qdrant vector database using
-`QDRANT_URL` and optional `QDRANT_API_KEY`; transcripts and analysis results are
-stored with lightweight embeddings for later retrieval.
+`QDRANT_URL` and optional `QDRANT_API_KEY`.  Raw transcripts are written to a
+`transcripts` collection while distilled analysis summaries land in an
+`analysis` collection, keeping sources and reasoning separate for retrieval.
 For audio transcription you can choose the Whisper model size by setting
 `WHISPER_MODEL` (defaults to `base`). The text analysis component relies on NLTK
 corpora which are downloaded automatically on first use.
@@ -84,9 +105,9 @@ Both approaches download the video, upload it to Google Drive, analyse the
 transcript, gather cross-platform discussions, flag basic logical fallacies,
 synthesise perspectives, score claim truthfulness and post a summary to
 Discord.
-Additionally, transcripts and analysis metadata are stored in a Qdrant
-collection so future agents can perform retrieval-augmented generation over the
-processed content.
+Additionally, transcripts and analysis metadata are stored in dedicated Qdrant
+collections so future agents can perform retrieval-augmented generation over
+the processed content.
 
 ## Understanding Your Crew
 

--- a/src/ultimate_discord_intelligence_bot/config/agents.yaml
+++ b/src/ultimate_discord_intelligence_bot/config/agents.yaml
@@ -47,3 +47,35 @@ truth_scoring_specialist:
   backstory: >-
     You track speaker reliability over time by assigning numerical scores based
     on accuracy of their claims.
+
+steelman_argument_generator:
+  role: Steelman Argument Generator
+  goal: Build the strongest possible version of a claim using supporting evidence.
+  backstory: >-
+    You synthesise search snippets from multiple backends into bulletproof
+    arguments that showcase the claim in its best light.
+
+discord_qa_manager:
+  role: Discord QA Manager
+  goal: Answer user questions using stored memory snippets.
+  backstory: >-
+    You query the vector database to pull relevant context for users in chat.
+
+ethan_defender:
+  role: Ethan Defender
+  goal: Always build the strongest possible case for Ethan’s claims.
+  backstory: |
+    You are “Traitor AB,” a tongue-in-cheek lawyer who defends Ethan’s takes on stream. You’re witty and informal; your summaries sound like Discord banter.
+
+hasan_defender:
+  role: Hasan Defender
+  goal: Always build the strongest possible case for Hasan’s arguments.
+  backstory: |
+    You are “Old Dan,” a based socialist lawyer who defends Hasan’s points with humor and flair. Keep it casual and punchy.
+
+character_profile_manager:
+  role: Character Profile Manager
+  goal: Maintain detailed profiles with trust scores and event history.
+  backstory: >-
+    You aggregate timeline events and verdicts to understand each person's
+    motives and reliability over time.

--- a/src/ultimate_discord_intelligence_bot/config/tasks.yaml
+++ b/src/ultimate_discord_intelligence_bot/config/tasks.yaml
@@ -22,8 +22,8 @@ identify_new_content:
 
 monitor_system:
   description: >-
-    Post an alert to the private Discord channel with the provided message.
-  expected_output: Confirmation that the alert was posted.
+    Gather basic system metrics and post them to the private Discord channel.
+  expected_output: Confirmation that the alert and metrics were posted.
   agent: system_alert_manager
 
 gather_cross_platform_intelligence:
@@ -42,6 +42,57 @@ fact_check_content:
 
 score_truthfulness:
   description: >-
-    Convert a list of fact-check verdicts into a numerical trust score.
-  expected_output: A score between 0 and 1 representing truthfulness.
+    Convert a list of fact-check verdicts about {person} into a numerical
+    trust score and update their historical profile.
+  expected_output: Updated profile with counts of truths and lies plus a score
+    between 0 and 1.
   agent: truth_scoring_specialist
+
+steelman_argument:
+  description: >-
+    Generate the strongest possible argument for {claim} using evidence snippets.
+  expected_output: Steelman argument text.
+  agent: steelman_argument_generator
+
+analyze_claim:
+  description: >-
+    Run the debate analysis pipeline on {url} at timestamp {ts} for {person}.
+    Produce context, fact-check results and score updates.
+  expected_output: Analysis report with defender blurbs and scoreboard deltas.
+  agent: content_manager
+
+get_context:
+  description: >-
+    Retrieve transcript context around {ts} in {video_id}.
+  expected_output: Surrounding transcript text.
+  agent: content_manager
+
+fact_check_claim:
+  description: >-
+    Fact-check the statement {claim} and return a verdict with evidence.
+  expected_output: Verdict and supporting citations.
+  agent: enhanced_fact_checker
+
+update_leaderboard:
+  description: >-
+    Update the lie, misquote and misinfo counts for {person}.
+  expected_output: Confirmation scores were persisted.
+  agent: truth_scoring_specialist
+
+answer_question:
+  description: >-
+    Retrieve relevant memory snippets to answer {question}.
+  expected_output: List of context snippets.
+  agent: discord_qa_manager
+
+get_timeline:
+  description: >-
+    Retrieve timeline events for {video_id}.
+  expected_output: Chronological list of events with sources.
+  agent: content_manager
+
+get_profile:
+  description: >-
+    Retrieve stored profile information for {person}.
+  expected_output: Profile with trust metrics and event history.
+  agent: character_profile_manager

--- a/src/ultimate_discord_intelligence_bot/crew.py
+++ b/src/ultimate_discord_intelligence_bot/crew.py
@@ -9,12 +9,22 @@ from .tools.perspective_synthesizer_tool import PerspectiveSynthesizerTool
 from .tools.social_media_monitor_tool import SocialMediaMonitorTool
 from .tools.multi_platform_monitor_tool import MultiPlatformMonitorTool
 from .tools.truth_scoring_tool import TruthScoringTool
+from .tools.trustworthiness_tracker_tool import TrustworthinessTrackerTool
+from .tools.fact_check_tool import FactCheckTool
+from .tools.leaderboard_tool import LeaderboardTool
+from .tools.debate_command_tool import DebateCommandTool
+from .tools.discord_qa_tool import DiscordQATool
+from .tools.steelman_argument_tool import SteelmanArgumentTool
 from .tools.yt_dlp_download_tool import (
     YouTubeDownloadTool,
     TwitchDownloadTool,
     KickDownloadTool,
     TwitterDownloadTool,
+    InstagramDownloadTool,
 )
+from .tools.character_profile_tool import CharacterProfileTool
+from .tools.x_monitor_tool import XMonitorTool
+from .tools.discord_monitor_tool import DiscordMonitorTool
 from .settings import DISCORD_PRIVATE_WEBHOOK
 
 
@@ -26,7 +36,7 @@ class UltimateDiscordIntelligenceBotCrew:
     def content_manager(self) -> Agent:
         return Agent(
             config=self.agents_config["content_manager"],
-            tools=[PipelineTool()],
+            tools=[PipelineTool(), DebateCommandTool()],
         )
 
     @agent
@@ -38,6 +48,7 @@ class UltimateDiscordIntelligenceBotCrew:
                 TwitchDownloadTool(),
                 KickDownloadTool(),
                 TwitterDownloadTool(),
+                InstagramDownloadTool(),
             ],
         )
 
@@ -60,21 +71,50 @@ class UltimateDiscordIntelligenceBotCrew:
     def cross_platform_intelligence_gatherer(self) -> Agent:
         return Agent(
             config=self.agents_config["cross_platform_intelligence_gatherer"],
-            tools=[SocialMediaMonitorTool()],
+            tools=[SocialMediaMonitorTool(), XMonitorTool(), DiscordMonitorTool()],
         )
 
     @agent
     def enhanced_fact_checker(self) -> Agent:
         return Agent(
             config=self.agents_config["enhanced_fact_checker"],
-            tools=[LogicalFallacyTool(), PerspectiveSynthesizerTool()],
+            tools=[LogicalFallacyTool(), PerspectiveSynthesizerTool(), FactCheckTool()],
         )
 
     @agent
     def truth_scoring_specialist(self) -> Agent:
         return Agent(
             config=self.agents_config["truth_scoring_specialist"],
-            tools=[TruthScoringTool()],
+            tools=[TruthScoringTool(), TrustworthinessTrackerTool(), LeaderboardTool()],
+        )
+
+    @agent
+    def steelman_argument_generator(self) -> Agent:
+        return Agent(
+            config=self.agents_config["steelman_argument_generator"],
+            tools=[SteelmanArgumentTool()],
+        )
+
+    @agent
+    def discord_qa_manager(self) -> Agent:
+        return Agent(
+            config=self.agents_config["discord_qa_manager"],
+            tools=[DiscordQATool()],
+        )
+
+    @agent
+    def ethan_defender(self) -> Agent:
+        return Agent(config=self.agents_config["ethan_defender"])
+
+    @agent
+    def hasan_defender(self) -> Agent:
+        return Agent(config=self.agents_config["hasan_defender"])
+
+    @agent
+    def character_profile_manager(self) -> Agent:
+        return Agent(
+            config=self.agents_config["character_profile_manager"],
+            tools=[CharacterProfileTool()],
         )
 
 
@@ -105,6 +145,38 @@ class UltimateDiscordIntelligenceBotCrew:
     @task
     def score_truthfulness(self) -> Task:
         return Task(config=self.tasks_config["score_truthfulness"])
+
+    @task
+    def steelman_argument(self) -> Task:
+        return Task(config=self.tasks_config["steelman_argument"])
+
+    @task
+    def analyze_claim(self) -> Task:
+        return Task(config=self.tasks_config["analyze_claim"])
+
+    @task
+    def get_context(self) -> Task:
+        return Task(config=self.tasks_config["get_context"])
+
+    @task
+    def fact_check_claim(self) -> Task:
+        return Task(config=self.tasks_config["fact_check_claim"])
+
+    @task
+    def update_leaderboard(self) -> Task:
+        return Task(config=self.tasks_config["update_leaderboard"])
+
+    @task
+    def answer_question(self) -> Task:
+        return Task(config=self.tasks_config["answer_question"])
+
+    @task
+    def get_timeline(self) -> Task:
+        return Task(config=self.tasks_config["get_timeline"])
+
+    @task
+    def get_profile(self) -> Task:
+        return Task(config=self.tasks_config["get_profile"])
 
     @crew
     def crew(self) -> Crew:

--- a/src/ultimate_discord_intelligence_bot/debate_analysis_pipeline.py
+++ b/src/ultimate_discord_intelligence_bot/debate_analysis_pipeline.py
@@ -1,0 +1,155 @@
+"""Lightweight pipeline for debate clip analysis."""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from .tools.yt_dlp_download_tool import YtDlpDownloadTool, YouTubeDownloadTool
+from .tools.audio_transcription_tool import AudioTranscriptionTool
+from .tools.transcript_index_tool import TranscriptIndexTool
+from .tools.context_verification_tool import ContextVerificationTool
+from .tools.fact_check_tool import FactCheckTool
+from .tools.leaderboard_tool import LeaderboardTool
+from .tools.timeline_tool import TimelineTool
+from .tools.memory_storage_tool import MemoryStorageTool
+from .tools.trustworthiness_tracker_tool import TrustworthinessTrackerTool
+from .tools.character_profile_tool import CharacterProfileTool
+
+
+class DebateAnalysisPipeline:
+    """Download, transcribe and analyse clips for context and accuracy."""
+
+    def __init__(
+        self,
+        downloader: Optional[YtDlpDownloadTool] = None,
+        transcriber: Optional[AudioTranscriptionTool] = None,
+        index_tool: Optional[TranscriptIndexTool] = None,
+        context_tool: Optional[ContextVerificationTool] = None,
+        fact_checker: Optional[FactCheckTool] = None,
+        leaderboard: Optional[LeaderboardTool] = None,
+        timeline: Optional[TimelineTool] = None,
+        memory_storage: Optional[MemoryStorageTool] = None,
+        trust_tracker: Optional[TrustworthinessTrackerTool] = None,
+        profile_tool: Optional[CharacterProfileTool] = None,
+        ethan_defender: Optional[Callable[[str], str]] = None,
+        hasan_defender: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self.downloader = downloader or YouTubeDownloadTool()
+        self.transcriber = transcriber or AudioTranscriptionTool()
+        self.index_tool = index_tool or TranscriptIndexTool()
+        self.context_tool = context_tool or ContextVerificationTool(self.index_tool)
+        self.fact_checker = fact_checker or FactCheckTool()
+        self.leaderboard = leaderboard or LeaderboardTool()
+        self.timeline = timeline or TimelineTool()
+        self.memory_storage = memory_storage
+        self.trust_tracker = trust_tracker or TrustworthinessTrackerTool()
+        self.profile_tool = profile_tool or CharacterProfileTool(
+            leaderboard=self.leaderboard, trust_tracker=self.trust_tracker
+        )
+        self.ethan_defender = ethan_defender
+        self.hasan_defender = hasan_defender
+
+    def analyze(
+        self,
+        url: str,
+        ts: float,
+        clip_text: str,
+        person: str,
+        transcript: str | None = None,
+    ) -> dict:
+        """Run context verification and fact-checking for a clip.
+
+        Parameters
+        ----------
+        url: str
+            Video URL or identifier.
+        ts: float
+            Timestamp of the clip in seconds.
+        clip_text: str
+            Text alleged to appear in the clip.
+        person: str
+            Person whose claim is being analysed.
+        transcript: str, optional
+            Pre-provided transcript to avoid downloading in tests.
+        """
+        video_id = url
+        if transcript is None:
+            download_info = self.downloader.run(url)
+            video_id = download_info.get("id", url)
+            local_path = download_info.get("local_path")
+            if local_path:
+                transcription = self.transcriber.run(local_path)
+                transcript = transcription.get("transcript", "")
+            else:
+                transcript = ""
+        self.index_tool.index_transcript(transcript or "", video_id)
+        context = self.context_tool.run(video_id=video_id, ts=ts, clip_text=clip_text)
+        fact = self.fact_checker.run(clip_text)
+        verdict = fact.get("verdict")
+        lies = 1 if verdict == "false" else 0
+        misquotes = 1 if context.get("verdict") == "missing-context" else 0
+        misinfo = 1 if fact.get("evidence") else 0
+        self.leaderboard.update_scores(person, lies, misquotes, misinfo)
+        self.trust_tracker.run(person, verdict != "false")
+        self.timeline.add_event(
+            video_id,
+            {
+                "ts": ts,
+                "clip": clip_text,
+                "context_verdict": context.get("verdict"),
+                "fact_verdict": fact.get("verdict"),
+                "evidence": fact.get("evidence", []),
+            },
+        )
+        self.profile_tool.record_event(
+            person,
+            {
+                "video_id": video_id,
+                "ts": ts,
+                "clip": clip_text,
+                "fact_verdict": verdict,
+                "context_verdict": context.get("verdict"),
+                "evidence": fact.get("evidence", []),
+            },
+        )
+        if self.memory_storage is not None:
+            self.memory_storage.run(
+                context.get("context", ""),
+                {
+                    "video_id": video_id,
+                    "ts": ts,
+                    "person": person,
+                    "clip_text": clip_text,
+                    "fact_verdict": fact.get("verdict"),
+                    "context_verdict": context.get("verdict"),
+                },
+                collection="analysis",
+            )
+        summary = (
+            f"clip: {clip_text}\n"
+            f"context_verdict: {context.get('verdict')}"
+            f" fact_verdict: {fact.get('verdict')}"
+        )
+        if self.ethan_defender is not None:
+            ethan_blurb = str(self.ethan_defender(summary))
+        else:
+            ethan_blurb = (
+                "Traitor AB: seems legit"
+                if lies == 0
+                else "Traitor AB: sketchy vibes"
+            )
+        if self.hasan_defender is not None:
+            hasan_blurb = str(self.hasan_defender(summary))
+        else:
+            hasan_blurb = (
+                "Old Dan: rock solid" if lies == 0 else "Old Dan: nah that's cap"
+            )
+        return {
+            "status": "success",
+            "context": context.get("context", ""),
+            "context_verdict": context.get("verdict", "uncertain"),
+            "fact_verdict": fact.get("verdict", "uncertain"),
+            "evidence": fact.get("evidence", []),
+            "deltas": {"lies": lies, "misquotes": misquotes, "misinfo": misinfo},
+            "ethan_defender": ethan_blurb[:180],
+            "hasan_defender": hasan_blurb[:180],
+        }

--- a/src/ultimate_discord_intelligence_bot/tools/__init__.py
+++ b/src/ultimate_discord_intelligence_bot/tools/__init__.py
@@ -7,6 +7,7 @@ from .yt_dlp_download_tool import (
     TwitchDownloadTool,
     KickDownloadTool,
     TwitterDownloadTool,
+    InstagramDownloadTool,
 )
 from .audio_transcription_tool import AudioTranscriptionTool
 from .discord_post_tool import DiscordPostTool
@@ -17,8 +18,21 @@ from .perspective_synthesizer_tool import PerspectiveSynthesizerTool
 from .pipeline_tool import PipelineTool
 from .social_media_monitor_tool import SocialMediaMonitorTool
 from .multi_platform_monitor_tool import MultiPlatformMonitorTool
+from .x_monitor_tool import XMonitorTool
+from .discord_monitor_tool import DiscordMonitorTool
 from .system_status_tool import SystemStatusTool
 from .truth_scoring_tool import TruthScoringTool
+from .trustworthiness_tracker_tool import TrustworthinessTrackerTool
+from .transcript_index_tool import TranscriptIndexTool
+from .context_verification_tool import ContextVerificationTool
+from .fact_check_tool import FactCheckTool
+from .leaderboard_tool import LeaderboardTool
+from .debate_command_tool import DebateCommandTool
+from .vector_search_tool import VectorSearchTool
+from .discord_qa_tool import DiscordQATool
+from .timeline_tool import TimelineTool
+from .character_profile_tool import CharacterProfileTool
+from .steelman_argument_tool import SteelmanArgumentTool
 
 __all__ = [
     "DiscordPrivateAlertTool",
@@ -27,6 +41,7 @@ __all__ = [
     "TwitchDownloadTool",
     "KickDownloadTool",
     "TwitterDownloadTool",
+    "InstagramDownloadTool",
     "AudioTranscriptionTool",
     "DiscordPostTool",
     "DriveUploadTool",
@@ -36,6 +51,19 @@ __all__ = [
     "PipelineTool",
     "SocialMediaMonitorTool",
     "MultiPlatformMonitorTool",
+    "XMonitorTool",
+    "DiscordMonitorTool",
     "SystemStatusTool",
     "TruthScoringTool",
+    "TrustworthinessTrackerTool",
+    "TranscriptIndexTool",
+    "ContextVerificationTool",
+    "FactCheckTool",
+    "LeaderboardTool",
+    "DebateCommandTool",
+    "VectorSearchTool",
+    "DiscordQATool",
+    "TimelineTool",
+    "CharacterProfileTool",
+    "SteelmanArgumentTool",
 ]

--- a/src/ultimate_discord_intelligence_bot/tools/character_profile_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/character_profile_tool.py
@@ -1,0 +1,80 @@
+"""Aggregate per-person trust metrics and events."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from crewai_tools import BaseTool
+
+from .. import settings
+from .leaderboard_tool import LeaderboardTool
+from .trustworthiness_tracker_tool import TrustworthinessTrackerTool
+
+
+class CharacterProfileTool(BaseTool):
+    """Store per-person events and summarise trust statistics."""
+
+    name: str = "Character Profile Tool"
+    description: str = (
+        "Persist events with sources and return combined trust metrics for a person."
+    )
+
+    def __init__(
+        self,
+        storage_path: Path | None = None,
+        leaderboard: LeaderboardTool | None = None,
+        trust_tracker: TrustworthinessTrackerTool | None = None,
+    ) -> None:
+        super().__init__()
+        self.storage_path = storage_path or settings.BASE_DIR / "character_profiles.json"
+        self.leaderboard = leaderboard or LeaderboardTool()
+        self.trust_tracker = trust_tracker or TrustworthinessTrackerTool()
+        if not self.storage_path.exists():
+            self._save({})
+
+    def _load(self) -> Dict[str, Dict[str, List[dict]]]:
+        try:
+            with self.storage_path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+
+    def _save(self, data: Dict[str, Dict[str, List[dict]]]) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.storage_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def record_event(self, person: str, event: dict) -> None:
+        data = self._load()
+        profile = data.get(person, {"events": []})
+        profile["events"].append(event)
+        data[person] = profile
+        self._save(data)
+
+    def get_profile(self, person: str) -> dict:
+        data = self._load()
+        profile = data.get(person, {"events": []})
+        board = self.leaderboard.get_person(person) or {
+            "person": person,
+            "lies": 0,
+            "misquotes": 0,
+            "misinfo": 0,
+        }
+        trust = self.trust_tracker._load().get(person, {"truths": 0, "lies": 0, "score": 0.0})
+        return {
+            "person": person,
+            "events": profile.get("events", []),
+            "leaderboard": {
+                "lies": board.get("lies", 0),
+                "misquotes": board.get("misquotes", 0),
+                "misinfo": board.get("misinfo", 0),
+            },
+            "trust": trust,
+        }
+
+    def _run(self, person: str) -> dict:
+        return {"status": "success", "profile": self.get_profile(person)}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/discord_monitor_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/discord_monitor_tool.py
@@ -1,0 +1,27 @@
+"""Monitor new messages from Discord channels."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from crewai_tools import BaseTool
+
+from .multi_platform_monitor_tool import MultiPlatformMonitorTool
+
+
+class DiscordMonitorTool(BaseTool):
+    """Return unseen Discord messages."""
+
+    name = "Discord Monitor Tool"
+    description = "Track new messages from Discord channels"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._monitor = MultiPlatformMonitorTool()
+
+    def _run(self, messages: Iterable[Dict[str, str]]) -> Dict[str, List[Dict[str, str]]]:
+        result = self._monitor._run(messages)
+        return {"status": "success", "new_messages": result["new_items"]}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/discord_qa_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/discord_qa_tool.py
@@ -1,0 +1,25 @@
+"""Discord-facing Q&A commands using vector search."""
+from __future__ import annotations
+
+from crewai_tools import BaseTool
+
+from .vector_search_tool import VectorSearchTool
+
+
+class DiscordQATool(BaseTool):
+    """Expose simple question-answering over stored memory."""
+
+    name: str = "Discord QA Tool"
+    description: str = "Answer questions using the vector database."
+
+    def __init__(self, search_tool: VectorSearchTool | None = None) -> None:
+        super().__init__()
+        self.search = search_tool or VectorSearchTool()
+
+    def _run(self, question: str, limit: int = 3):
+        hits = self.search.run(question, limit=limit)
+        snippets = [h.get("text", "") for h in hits]
+        return {"status": "success", "snippets": snippets}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/fact_check_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/fact_check_tool.py
@@ -1,0 +1,41 @@
+"""Basic fact-checking via DuckDuckGo search."""
+from __future__ import annotations
+
+import requests
+from crewai_tools import BaseTool
+
+
+class FactCheckTool(BaseTool):
+    """Search external sources to gather evidence for or against a claim."""
+
+    name: str = "Fact Check Tool"
+    description: str = "Use web search to collect evidence for a claim."
+
+    def _run(self, claim: str) -> dict:
+        try:
+            params = {"q": claim, "format": "json", "no_redirect": 1, "no_html": 1}
+            resp = requests.get("https://api.duckduckgo.com/", params=params, timeout=10)
+            data = resp.json()
+            topics = data.get("RelatedTopics", [])
+            evidence = []
+            for item in topics[:3]:
+                if isinstance(item, dict) and item.get("Text") and item.get("FirstURL"):
+                    evidence.append(
+                        {
+                            "title": item["Text"],
+                            "url": item["FirstURL"],
+                            "snippet": item["Text"],
+                        }
+                    )
+            verdict = "true" if "confirmed" in claim.lower() else "uncertain"
+            return {
+                "status": "success",
+                "verdict": verdict,
+                "evidence": evidence,
+                "notes": "verdict is heuristic; evidence list may require manual review",
+            }
+        except Exception as exc:  # pragma: no cover - network errors handled
+            return {"status": "error", "error": str(exc)}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/leaderboard_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/leaderboard_tool.py
@@ -1,0 +1,81 @@
+"""Persist and retrieve per-person lie/misquote/misinfo counts."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from crewai_tools import BaseTool
+
+from .. import settings
+
+
+class LeaderboardTool(BaseTool):
+    """Simple JSON-backed scoreboard for misinformation tracking."""
+
+    name: str = "Leaderboard Tool"
+    description: str = "Maintain counts of lies, misquotes and misinfo per person."
+
+    def __init__(self, storage_path: Path | None = None):
+        super().__init__()
+        self.storage_path = storage_path or settings.BASE_DIR / "leaderboard.json"
+        if not self.storage_path.exists():
+            self._save({})
+
+    def _load(self) -> Dict[str, Dict[str, int]]:
+        try:
+            with self.storage_path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+
+    def _save(self, data: Dict[str, Dict[str, int]]) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.storage_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def update_scores(
+        self, person: str, lies_delta: int, misquotes_delta: int, misinfo_delta: int
+    ) -> None:
+        data = self._load()
+        record = data.get(person, {"lies": 0, "misquotes": 0, "misinfo": 0})
+        record["lies"] += lies_delta
+        record["misquotes"] += misquotes_delta
+        record["misinfo"] += misinfo_delta
+        data[person] = record
+        self._save(data)
+
+    def get_top(self, n: int = 10) -> List[Dict[str, int]]:
+        data = self._load()
+        items = [
+            {"person": person, **scores} for person, scores in data.items()
+        ]
+        items.sort(key=lambda x: (x["lies"] + x["misquotes"] + x["misinfo"]), reverse=True)
+        return items[:n]
+
+    def get_person(self, person: str) -> Optional[Dict[str, int]]:
+        """Return scoreboard counts for a single person."""
+        data = self._load()
+        record = data.get(person)
+        if record is None:
+            return None
+        return {"person": person, **record}
+
+    def _run(self, action: str, **kwargs):
+        if action == "update":
+            self.update_scores(
+                kwargs["person"],
+                kwargs.get("lies_delta", 0),
+                kwargs.get("misquotes_delta", 0),
+                kwargs.get("misinfo_delta", 0),
+            )
+            return {"status": "success"}
+        if action == "top":
+            return {"status": "success", "results": self.get_top(kwargs.get("n", 10))}
+        if action == "get":
+            result = self.get_person(kwargs["person"])
+            return {"status": "success", "result": result} if result else {"status": "error", "error": "not found"}
+        return {"status": "error", "error": "unknown action"}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/steelman_argument_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/steelman_argument_tool.py
@@ -1,0 +1,49 @@
+"""Compose the strongest supportive argument for a claim."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from crewai_tools import BaseTool
+
+
+class SteelmanArgumentTool(BaseTool):
+    """Combine evidence snippets into a steelman argument."""
+
+    name: str = "Steelman Argument Tool"
+    description: str = (
+        "Build the strongest possible version of a claim using supporting snippets"
+    )
+
+    def _run(self, claim: str, evidence: List[Dict[str, str]]) -> Dict[str, str]:
+        """Craft a steelman argument.
+
+        Parameters
+        ----------
+        claim:
+            The statement to strengthen.
+        evidence:
+            Sequence of dicts containing at least a ``snippet`` field with
+            supportive text and optional ``source`` metadata.
+        """
+
+        snippets: List[str] = []
+        for item in evidence:
+            snippet = item.get("snippet")
+            if snippet:
+                source = item.get("source")
+                if source:
+                    snippets.append(f"[{source}] {snippet}")
+                else:
+                    snippets.append(snippet)
+        if not snippets:
+            return {
+                "status": "uncertain",
+                "argument": claim,
+                "notes": "no supporting evidence provided",
+            }
+        argument = f"{claim}. " + " ".join(snippets)
+        return {"status": "success", "argument": argument}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/timeline_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/timeline_tool.py
@@ -1,0 +1,58 @@
+"""Persist and retrieve chronological events with references."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from crewai_tools import BaseTool
+
+from .. import settings
+
+
+class TimelineTool(BaseTool):
+    """Store timeline events per video with sources."""
+
+    name: str = "Timeline Tool"
+    description: str = "Record and fetch timeline events for videos."
+
+    def __init__(self, storage_path: Path | None = None):
+        super().__init__()
+        self.storage_path = storage_path or settings.BASE_DIR / "timeline.json"
+        if not self.storage_path.exists():
+            self._save({})
+
+    def _load(self) -> Dict[str, List[dict]]:
+        try:
+            with self.storage_path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+
+    def _save(self, data: Dict[str, List[dict]]) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.storage_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def add_event(self, video_id: str, event: dict) -> None:
+        data = self._load()
+        events = data.get(video_id, [])
+        events.append(event)
+        events.sort(key=lambda x: x.get("ts", 0))
+        data[video_id] = events
+        self._save(data)
+
+    def get_timeline(self, video_id: str) -> List[dict]:
+        data = self._load()
+        return data.get(video_id, [])
+
+    def _run(self, action: str, **kwargs):
+        if action == "add":
+            self.add_event(kwargs["video_id"], kwargs.get("event", {}))
+            return {"status": "success"}
+        if action == "get":
+            return {"status": "success", "events": self.get_timeline(kwargs["video_id"])}
+        return {"status": "error", "error": "unknown action"}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/transcript_index_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/transcript_index_tool.py
@@ -1,0 +1,49 @@
+"""Index transcripts into timestamped chunks and retrieve context."""
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from crewai_tools import BaseTool
+
+
+class TranscriptIndexTool(BaseTool):
+    """Store transcript chunks for later context lookup."""
+
+    name: str = "Transcript Index Tool"
+    description: str = (
+        "Index transcripts into timestamped windows and fetch surrounding context."
+    )
+
+    def __init__(self, window: float = 30.0):
+        super().__init__()
+        self.window = window
+        self.indices: Dict[str, List[Tuple[float, float, str]]] = {}
+
+    def index_transcript(self, transcript: str, video_id: str) -> dict:
+        """Split a transcript into timestamped chunks and store them."""
+        chunks: List[Tuple[float, float, str]] = []
+        for i, line in enumerate(transcript.splitlines()):
+            start = i * self.window
+            end = start + self.window
+            chunks.append((start, end, line))
+        self.indices[video_id] = chunks
+        return {"status": "success", "chunks": len(chunks)}
+
+    def get_context(self, video_id: str, ts: float, window: float = 45.0) -> str:
+        """Return transcript text around a timestamp within a window."""
+        chunks = self.indices.get(video_id, [])
+        context: List[str] = []
+        for start, end, text in chunks:
+            if end < ts - window:
+                continue
+            if start > ts + window:
+                break
+            context.append(text)
+        return " ".join(context)
+
+    # expose indexing via BaseTool run
+    def _run(self, transcript: str, video_id: str) -> dict:
+        return self.index_transcript(transcript, video_id)
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/vector_search_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/vector_search_tool.py
@@ -1,0 +1,61 @@
+"""Search Qdrant memory for relevant documents."""
+from __future__ import annotations
+
+import os
+from typing import Callable, Dict, List, Optional
+
+from crewai_tools import BaseTool
+
+try:  # pragma: no cover - optional dependency
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import Distance, VectorParams
+except Exception:  # pragma: no cover - used for testing without qdrant
+    QdrantClient = None  # type: ignore
+
+
+class VectorSearchTool(BaseTool):
+    """Retrieve stored text snippets from a Qdrant collection."""
+
+    name: str = "Qdrant Vector Search Tool"
+    description: str = "Query the vector database for similar documents." 
+
+    def __init__(
+        self,
+        client: Optional[object] = None,
+        collection: str | None = None,
+        embedding_fn: Optional[Callable[[str], List[float]]] = None,
+    ) -> None:
+        super().__init__()
+        self.collection = collection or "content"
+        self.embedding_fn = embedding_fn or (lambda text: [float(len(text))])
+        if client is not None:
+            self.client = client
+        else:
+            if QdrantClient is None:  # pragma: no cover - real client missing
+                raise RuntimeError("qdrant-client package is not installed")
+            url = os.getenv("QDRANT_URL", "http://localhost:6333")
+            api_key = os.getenv("QDRANT_API_KEY")
+            self.client = QdrantClient(url=url, api_key=api_key)
+        self._ensure_collection(self.collection)
+
+    def _ensure_collection(self, name: str) -> None:  # pragma: no cover - setup
+        try:
+            self.client.get_collection(name)
+        except Exception:
+            self.client.recreate_collection(
+                name,
+                vectors_config=VectorParams(size=1, distance=Distance.COSINE),
+            )
+
+    def _run(self, query: str, limit: int = 3, collection: str | None = None) -> List[Dict]:
+        target = collection or self.collection
+        vector = self.embedding_fn(query)
+        hits = self.client.search(
+            collection_name=target,
+            query_vector=vector,
+            limit=limit,
+        )
+        return [getattr(hit, "payload", {}) for hit in hits]
+
+    def run(self, query: str, limit: int = 3, collection: str | None = None):  # pragma: no cover - thin wrapper
+        return self._run(query, limit=limit, collection=collection)

--- a/src/ultimate_discord_intelligence_bot/tools/x_monitor_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/x_monitor_tool.py
@@ -1,0 +1,32 @@
+"""Monitor new posts from X/Twitter.
+
+This lightweight wrapper reuses :class:`MultiPlatformMonitorTool` to track
+unseen tweet IDs. It exposes a clearer interface for crews that specifically
+watch X feeds.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from crewai_tools import BaseTool
+
+from .multi_platform_monitor_tool import MultiPlatformMonitorTool
+
+
+class XMonitorTool(BaseTool):
+    """Return unseen tweets."""
+
+    name = "X Monitor Tool"
+    description = "Track new posts from X/Twitter feeds"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._monitor = MultiPlatformMonitorTool()
+
+    def _run(self, posts: Iterable[Dict[str, str]]) -> Dict[str, List[Dict[str, str]]]:
+        result = self._monitor._run(posts)
+        return {"status": "success", "new_posts": result["new_items"]}
+
+    def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper
+        return self._run(*args, **kwargs)

--- a/src/ultimate_discord_intelligence_bot/tools/yt_dlp_download_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/yt_dlp_download_tool.py
@@ -122,3 +122,9 @@ class TwitterDownloadTool(YtDlpDownloadTool):
     description = "Download videos from X/Twitter"
     platform = "Twitter"
 
+
+class InstagramDownloadTool(YtDlpDownloadTool):
+    name = "Instagram Download Tool"
+    description = "Download Instagram reels or posts"
+    platform = "Instagram"
+

--- a/tests/test_character_profile_tool.py
+++ b/tests/test_character_profile_tool.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from ultimate_discord_intelligence_bot.tools.character_profile_tool import (
+    CharacterProfileTool,
+)
+from ultimate_discord_intelligence_bot.tools.leaderboard_tool import LeaderboardTool
+from ultimate_discord_intelligence_bot.tools.trustworthiness_tracker_tool import (
+    TrustworthinessTrackerTool,
+)
+
+
+def test_character_profile_tool(tmp_path: Path) -> None:
+    leaderboard_path = tmp_path / "board.json"
+    trust_path = tmp_path / "trust.json"
+    profile_path = tmp_path / "profiles.json"
+    leaderboard = LeaderboardTool(storage_path=leaderboard_path)
+    trust = TrustworthinessTrackerTool(storage_path=trust_path)
+    tool = CharacterProfileTool(
+        storage_path=profile_path, leaderboard=leaderboard, trust_tracker=trust
+    )
+
+    leaderboard.update_scores("bob", 1, 0, 0)
+    trust.run("bob", False)
+    tool.record_event("bob", {"video_id": "vid", "ts": 1, "clip": "hi"})
+
+    result = tool.run("bob")
+    profile = result["profile"]
+    assert profile["leaderboard"]["lies"] == 1
+    assert profile["trust"]["lies"] == 1
+    assert profile["events"][0]["video_id"] == "vid"

--- a/tests/test_context_verification_tool.py
+++ b/tests/test_context_verification_tool.py
@@ -1,0 +1,12 @@
+from ultimate_discord_intelligence_bot.tools.transcript_index_tool import TranscriptIndexTool
+from ultimate_discord_intelligence_bot.tools.context_verification_tool import ContextVerificationTool
+
+
+def test_verify_clip_context():
+    idx = TranscriptIndexTool(window=30.0)
+    idx.index_transcript("line1\nline2", "vid")
+    tool = ContextVerificationTool(index_tool=idx)
+    res = tool.run(video_id="vid", ts=15, clip_text="line1")
+    assert res["verdict"] == "in-context"
+    res2 = tool.run(video_id="vid", ts=15, clip_text="other")
+    assert res2["verdict"] == "missing-context"

--- a/tests/test_debate_analysis_pipeline.py
+++ b/tests/test_debate_analysis_pipeline.py
@@ -1,0 +1,61 @@
+from ultimate_discord_intelligence_bot.debate_analysis_pipeline import DebateAnalysisPipeline
+from ultimate_discord_intelligence_bot.tools.leaderboard_tool import LeaderboardTool
+from ultimate_discord_intelligence_bot.tools.debate_command_tool import DebateCommandTool
+from ultimate_discord_intelligence_bot.tools.timeline_tool import TimelineTool
+from ultimate_discord_intelligence_bot.tools.trustworthiness_tracker_tool import (
+    TrustworthinessTrackerTool,
+)
+from ultimate_discord_intelligence_bot.tools.character_profile_tool import (
+    CharacterProfileTool,
+)
+
+
+class DummyMemory:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, text, metadata, collection=None):
+        self.calls.append((text, metadata, collection))
+        return {"status": "success"}
+
+
+def test_debate_pipeline_smoke(tmp_path):
+    lb = LeaderboardTool(storage_path=tmp_path / "lb.json")
+    tl = TimelineTool(storage_path=tmp_path / "timeline.json")
+    trust = TrustworthinessTrackerTool(storage_path=tmp_path / "trust.json")
+    profile = CharacterProfileTool(
+        storage_path=tmp_path / "profiles.json", leaderboard=lb, trust_tracker=trust
+    )
+    memory = DummyMemory()
+    pipeline = DebateAnalysisPipeline(
+        leaderboard=lb,
+        timeline=tl,
+        memory_storage=memory,
+        trust_tracker=trust,
+        profile_tool=profile,
+        ethan_defender=lambda _: "Ethan closing",
+        hasan_defender=lambda _: "Hasan closing",
+    )
+    tool = DebateCommandTool(pipeline=pipeline)
+    transcript = "hello there\nthis is a test"
+    result = tool.run(
+        "analyze",
+        url="video1",
+        ts=5,
+        clip_text="hello",
+        person="hasan",
+        transcript=transcript,
+    )
+    assert result["status"] == "success"
+    top = lb.get_top()
+    assert top and top[0]["person"] == "hasan"
+    events = tl.get_timeline("video1")
+    assert events and events[0]["clip"] == "hello"
+    assert memory.calls and memory.calls[0][1]["video_id"] == "video1"
+    assert memory.calls[0][2] == "analysis"
+    prof = profile.get_profile("hasan")
+    assert prof["leaderboard"]["lies"] in (0, 1)
+    assert result["ethan_defender"] == "Ethan closing"
+    assert result["hasan_defender"] == "Hasan closing"
+    cmd_profile = tool.run("profile", person="hasan")
+    assert cmd_profile["status"] == "success"

--- a/tests/test_discord_monitor_tool.py
+++ b/tests/test_discord_monitor_tool.py
@@ -1,0 +1,13 @@
+from ultimate_discord_intelligence_bot.tools.discord_monitor_tool import DiscordMonitorTool
+
+
+def test_discord_monitor_tool_filters_seen_messages():
+    tool = DiscordMonitorTool()
+    messages = [
+        {"id": "m1", "url": "https://discord.com/ch/1", "author": "mod", "timestamp": "1"},
+        {"id": "m2", "url": "https://discord.com/ch/2", "author": "user", "timestamp": "2"},
+    ]
+    first = tool._run(messages)
+    assert len(first["new_messages"]) == 2
+    second = tool._run(messages)
+    assert len(second["new_messages"]) == 0

--- a/tests/test_discord_qa_tool.py
+++ b/tests/test_discord_qa_tool.py
@@ -1,0 +1,13 @@
+from unittest.mock import MagicMock
+
+from ultimate_discord_intelligence_bot.tools.discord_qa_tool import DiscordQATool
+
+
+def test_discord_qa_tool_returns_snippets():
+    search = MagicMock()
+    search.run.return_value = [{"text": "result"}]
+    tool = DiscordQATool(search_tool=search)
+    out = tool.run("question")
+    assert out["status"] == "success"
+    assert out["snippets"] == ["result"]
+    search.run.assert_called_once()

--- a/tests/test_fact_check_tool.py
+++ b/tests/test_fact_check_tool.py
@@ -1,0 +1,24 @@
+import types
+
+import requests
+
+from ultimate_discord_intelligence_bot.tools.fact_check_tool import FactCheckTool
+
+
+def test_fact_check(monkeypatch):
+    def fake_get(url, params=None, timeout=10):
+        class Resp:
+            def json(self):
+                return {
+                    "RelatedTopics": [
+                        {"Text": "Example", "FirstURL": "http://example.com"}
+                    ]
+                }
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    tool = FactCheckTool()
+    result = tool.run("sample claim")
+    assert result["status"] == "success"
+    assert result["evidence"]

--- a/tests/test_leaderboard_tool.py
+++ b/tests/test_leaderboard_tool.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from ultimate_discord_intelligence_bot.tools.leaderboard_tool import LeaderboardTool
+
+
+def test_update_and_get_top(tmp_path):
+    storage = tmp_path / "board.json"
+    tool = LeaderboardTool(storage)
+    tool.update_scores("Alice", 1, 2, 3)
+    tool.update_scores("Bob", 0, 1, 0)
+    top = tool.get_top()
+    assert top[0]["person"] == "Alice"
+    assert top[0]["lies"] == 1 and top[0]["misinfo"] == 3

--- a/tests/test_memory_storage_tool.py
+++ b/tests/test_memory_storage_tool.py
@@ -10,8 +10,8 @@ def test_memory_storage_tool_upsert_called():
     client.upsert.return_value = None
 
     tool = MemoryStorageTool(client=client, embedding_fn=lambda t: [0.1])
-    result = tool.run("hello", {"meta": 1})
+    result = tool.run("hello", {"meta": 1}, collection="analysis")
 
     assert result["status"] == "success"
-    client.recreate_collection.assert_called_once()
+    assert client.recreate_collection.call_count == 2
     client.upsert.assert_called_once()

--- a/tests/test_multi_platform_download_tools.py
+++ b/tests/test_multi_platform_download_tools.py
@@ -6,12 +6,13 @@ from ultimate_discord_intelligence_bot.tools.yt_dlp_download_tool import (
     TwitchDownloadTool,
     KickDownloadTool,
     TwitterDownloadTool,
+    InstagramDownloadTool,
 )
 
 
 @pytest.mark.parametrize(
     "tool_cls",
-    [TwitchDownloadTool, KickDownloadTool, TwitterDownloadTool],
+    [TwitchDownloadTool, KickDownloadTool, TwitterDownloadTool, InstagramDownloadTool],
 )
 def test_downloader_reports_platform(monkeypatch, tool_cls):
     def fake_run(cmd, capture_output, text, timeout, env):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -62,7 +62,7 @@ def test_process_video(monkeypatch):
     analyzer.run.assert_called_once()
     fallacy.run.assert_called_once()
     perspective.run.assert_called_once()
-    memory.run.assert_called_once()
+    assert memory.run.call_count == 2
     discord.run.assert_called_once()
 
 
@@ -77,6 +77,7 @@ def test_download_failure(monkeypatch):
     fallacy = MagicMock()
     perspective = MagicMock()
     memory = MagicMock()
+    memory.run.return_value = {"status": "success"}
 
     pipeline = ContentPipeline(
         webhook_url="http://example.com",
@@ -168,7 +169,7 @@ def test_drive_upload_retry(monkeypatch):
 
     assert result["status"] == "success"
     assert drive.run.call_count == 2
-    memory.run.assert_called_once()
+    assert memory.run.call_count == 2
 
 
 def test_exception_in_analysis(monkeypatch):
@@ -218,7 +219,7 @@ def test_exception_in_analysis(monkeypatch):
     discord.run.assert_not_called()
     fallacy.run.assert_not_called()
     perspective.run.assert_not_called()
-    memory.run.assert_not_called()
+    assert memory.run.call_count >= 1
 
 
 def test_unsupported_platform(monkeypatch):

--- a/tests/test_steelman_argument_tool.py
+++ b/tests/test_steelman_argument_tool.py
@@ -1,0 +1,25 @@
+from ultimate_discord_intelligence_bot.tools.steelman_argument_tool import (
+    SteelmanArgumentTool,
+)
+
+
+def test_steelman_argument_tool_combines_evidence():
+    tool = SteelmanArgumentTool()
+    claim = "Universal healthcare improves outcomes"
+    evidence = [
+        {"source": "study", "snippet": "countries with universal coverage live longer"},
+        {"source": "report", "snippet": "families face fewer medical bankruptcies"},
+    ]
+    result = tool.run(claim=claim, evidence=evidence)
+    assert result["status"] == "success"
+    assert "universal coverage" in result["argument"].lower()
+    assert claim in result["argument"]
+
+
+def test_steelman_argument_tool_handles_no_evidence():
+    tool = SteelmanArgumentTool()
+    claim = "Water is wet"
+    result = tool.run(claim=claim, evidence=[])
+    assert result["status"] == "uncertain"
+    assert result["argument"] == claim
+    assert "no supporting evidence" in result["notes"]

--- a/tests/test_timeline_tool.py
+++ b/tests/test_timeline_tool.py
@@ -1,0 +1,9 @@
+from ultimate_discord_intelligence_bot.tools.timeline_tool import TimelineTool
+
+
+def test_timeline_tool_add_get(tmp_path):
+    tool = TimelineTool(storage_path=tmp_path / "timeline.json")
+    tool.add_event("vid", {"ts": 2, "desc": "later"})
+    tool.add_event("vid", {"ts": 1, "desc": "earlier"})
+    events = tool.get_timeline("vid")
+    assert events[0]["ts"] == 1 and events[1]["ts"] == 2

--- a/tests/test_transcript_index_tool.py
+++ b/tests/test_transcript_index_tool.py
@@ -1,0 +1,10 @@
+from ultimate_discord_intelligence_bot.tools.transcript_index_tool import TranscriptIndexTool
+
+
+def test_index_and_get_context():
+    tool = TranscriptIndexTool(window=30.0)
+    transcript = "hello\nworld\nfoo"
+    res = tool.index_transcript(transcript, "vid1")
+    assert res["status"] == "success" and res["chunks"] == 3
+    ctx = tool.get_context("vid1", ts=35)
+    assert "world" in ctx

--- a/tests/test_trustworthiness_tracker_tool.py
+++ b/tests/test_trustworthiness_tracker_tool.py
@@ -1,0 +1,17 @@
+import json
+from ultimate_discord_intelligence_bot.tools.trustworthiness_tracker_tool import (
+    TrustworthinessTrackerTool,
+)
+
+
+def test_tracker_updates_counts(tmp_path):
+    path = tmp_path / "trust.json"
+    tool = TrustworthinessTrackerTool(storage_path=path)
+    first = tool.run(person="Alice", verdict=True)
+    assert first["score"] == 1.0
+    second = tool.run(person="Alice", verdict=False)
+    assert second["score"] == 0.5
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["Alice"]["truths"] == 1
+    assert data["Alice"]["lies"] == 1

--- a/tests/test_vector_search_tool.py
+++ b/tests/test_vector_search_tool.py
@@ -1,0 +1,17 @@
+from unittest.mock import MagicMock
+
+from ultimate_discord_intelligence_bot.tools.vector_search_tool import VectorSearchTool
+
+
+def test_vector_search_tool_queries_client():
+    client = MagicMock()
+    client.get_collection.return_value = None
+    client.search.return_value = [MagicMock(payload={"text": "hello"})]
+
+    tool = VectorSearchTool(client=client, embedding_fn=lambda t: [0.1])
+    results = tool.run("hi", limit=1, collection="analysis")
+
+    assert results == [{"text": "hello"}]
+    client.search.assert_called_once()
+    args, kwargs = client.search.call_args
+    assert kwargs.get("collection_name") == "analysis"

--- a/tests/test_x_monitor_tool.py
+++ b/tests/test_x_monitor_tool.py
@@ -1,0 +1,13 @@
+from ultimate_discord_intelligence_bot.tools.x_monitor_tool import XMonitorTool
+
+
+def test_x_monitor_tool_filters_seen_posts():
+    tool = XMonitorTool()
+    posts = [
+        {"id": "1", "url": "https://x.com/a", "author": "alice", "timestamp": "1"},
+        {"id": "2", "url": "https://x.com/b", "author": "bob", "timestamp": "2"},
+    ]
+    first = tool._run(posts)
+    assert len(first["new_posts"]) == 2
+    second = tool._run(posts)
+    assert len(second["new_posts"]) == 0


### PR DESCRIPTION
## Summary
- add character profile tool to aggregate timeline events and trust metrics
- wire trust tracker and profile updates into debate analysis and commands
- expose `/profile` command with crew agent and task for profile retrieval
- allow custom defender blurbs via pluggable callables
- document repository workflow and goals in AGENTS.md
- introduce steelman argument generator agent and tool for stronger claim reasoning
- add Instagram download support and monitoring tools for X posts and Discord messages
- refine contributor guidelines with core principles and contribution template
- support multiple Qdrant collections so transcripts and analysis stay separate

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac1b384820832e97349733b85455be