### PR TITLE
feat: add TikTok download tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ The checklist below tracks major components of the system and their status.
 - [x] System alert manager for Discord-only monitoring.
 - [x] Cross-platform intelligence gatherer agent.
 - [x] Steelman argument generator.
-- [x] Twitch, Kick, Twitter, Instagram downloaders and X/Discord monitor tools.
+- [x] Twitch, Kick, Twitter, Instagram, TikTok downloaders and X/Discord monitor tools.
 - [x] Qdrant collections separated for transcripts and analyses.
 - [x] Enhanced fact-checking backends (Serply, EXA, Perplexity, WolframAlpha).
 - [x] Expanded logical fallacy detection.

--- a/src/ultimate_discord_intelligence_bot/tools/__init__.py
+++ b/src/ultimate_discord_intelligence_bot/tools/__init__.py
@@ -8,6 +8,7 @@ from .yt_dlp_download_tool import (
     KickDownloadTool,
     TwitterDownloadTool,
     InstagramDownloadTool,
+    TikTokDownloadTool,
 )
 from .audio_transcription_tool import AudioTranscriptionTool
 from .discord_post_tool import DiscordPostTool
@@ -42,6 +43,7 @@ __all__ = [
     "KickDownloadTool",
     "TwitterDownloadTool",
     "InstagramDownloadTool",
+    "TikTokDownloadTool",
     "AudioTranscriptionTool",
     "DiscordPostTool",
     "DriveUploadTool",

--- a/src/ultimate_discord_intelligence_bot/tools/yt_dlp_download_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/yt_dlp_download_tool.py
@@ -68,6 +68,13 @@ class YtDlpDownloadTool(BaseTool):
             if result.returncode == 0:
                 output_lines = result.stdout.strip().split("\n")
                 download_info = output_lines[-1].split("|")
+                if len(download_info) != 6:
+                    return {
+                        "status": "error",
+                        "platform": self.platform,
+                        "error": f"Unexpected yt-dlp output: {output_lines[-1]}",
+                        "command": " ".join(command),
+                    }
                 local_path = download_info[5]
                 return {
                     "status": "success",
@@ -89,7 +96,11 @@ class YtDlpDownloadTool(BaseTool):
                 }
 
         except subprocess.TimeoutExpired:
-            return {"status": "error", "platform": self.platform, "error": "Download timeout after 30 minutes"}
+            return {
+                "status": "error",
+                "platform": self.platform,
+                "error": "Download timeout after 30 minutes",
+            }
         except Exception as e:  # pragma: no cover - defensive logging path
             logging.exception("%s download failed", self.platform)
             return {"status": "error", "platform": self.platform, "error": str(e)}
@@ -127,4 +138,10 @@ class InstagramDownloadTool(YtDlpDownloadTool):
     name = "Instagram Download Tool"
     description = "Download Instagram reels or posts"
     platform = "Instagram"
+
+
+class TikTokDownloadTool(YtDlpDownloadTool):
+    name = "TikTok Download Tool"
+    description = "Download TikTok videos"
+    platform = "TikTok"
 

--- a/tests/test_multi_platform_download_tools.py
+++ b/tests/test_multi_platform_download_tools.py
@@ -7,12 +7,19 @@ from ultimate_discord_intelligence_bot.tools.yt_dlp_download_tool import (
     KickDownloadTool,
     TwitterDownloadTool,
     InstagramDownloadTool,
+    TikTokDownloadTool,
 )
 
 
 @pytest.mark.parametrize(
     "tool_cls",
-    [TwitchDownloadTool, KickDownloadTool, TwitterDownloadTool, InstagramDownloadTool],
+    [
+        TwitchDownloadTool,
+        KickDownloadTool,
+        TwitterDownloadTool,
+        InstagramDownloadTool,
+        TikTokDownloadTool,
+    ],
 )
 def test_downloader_reports_platform(monkeypatch, tool_cls):
     def fake_run(cmd, capture_output, text, timeout, env):
@@ -29,4 +36,20 @@ def test_downloader_reports_platform(monkeypatch, tool_cls):
     assert result["platform"] == tool.platform
     assert result["status"] == "success"
     assert result["local_path"].endswith("title [id].mp4")
+
+
+def test_downloader_handles_malformed_output(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout, env):
+        class Result:
+            returncode = 0
+            stdout = "unexpected"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    tool = TikTokDownloadTool()
+    result = tool._run("http://example.com")
+    assert result["status"] == "error"
+    assert "Unexpected yt-dlp output" in result["error"]
 


### PR DESCRIPTION
## Summary
- add TikTokDownloadTool subclass to the yt-dlp wrapper and expose it through the tools registry
- cover the TikTok downloader in the multi-platform download tests
- harden yt-dlp output parsing and verify error handling

## Progress Tracker
- [x] TikTok download tool integrated
- [x] Tests covering new downloader
- [x] yt-dlp output parsing validated

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac3c6dc6dc832ea3a72637635c1a47