### PR TITLE
feat: add prompt engine and model router services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Follow this checklist whenever adding agents, tasks, tools, or workflows:
 
 ## Project Goals
 1. Build a debate-analysis system with partisan defenders (Traitor AB & Old Dan).
-2. Ingest videos and transcripts from multiple platforms (YouTube, Twitch, Kick, Twitter/X, Instagram, Discord).
+2. Ingest videos and transcripts from multiple platforms (YouTube, Twitch, Kick, Twitter/X, Instagram, TikTok, Reddit, Discord).
 3. Verify clip context, fact‑check claims, and trace misinfo sources.
 4. Maintain persistent scores for lies, misquotes, misinfo, and trustworthiness.
 5. Store transcripts, analyses, and social context in Qdrant for retrieval.
@@ -57,7 +57,7 @@ The checklist below tracks major components of the system and their status.
 - [x] System alert manager for Discord-only monitoring.
 - [x] Cross-platform intelligence gatherer agent.
 - [x] Steelman argument generator.
-- [x] Twitch, Kick, Twitter, Instagram downloaders and X/Discord monitor tools.
+- [x] Twitch, Kick, Twitter, Instagram, TikTok, Reddit, Discord downloaders and X/Discord monitor tools.
 - [x] Qdrant collections separated for transcripts and analyses.
 - [x] Enhanced fact-checking backends (Serply, EXA, Perplexity, WolframAlpha).
 - [x] Expanded logical fallacy detection.
@@ -65,5 +65,18 @@ The checklist below tracks major components of the system and their status.
 - [x] Full workflow tests for new ingestion sources.
 - [x] Personality Synthesis Manager agent.
 - [x] Additional monitoring and alerting enhancements.
+- [x] Unified multi-platform download dispatcher.
+- [x] Content pipeline uses multi-platform dispatcher for TikTok and Reddit downloads.
+- [x] Agent and task configs updated for TikTok and Reddit coverage.
+- [x] yt-dlp downloaders respect optional quality parameter.
+- [x] Content pipeline exposes optional quality override.
+- [x] Prompt engine and token counter service available globally.
+- [x] OpenRouter-based model router with learning feedback.
+- [x] In-memory memory retrieval service.
+- [x] Perspective synthesizer grounded by memory retrieval.
+- [x] Token counter leverages transformers tokenizers for non-OpenAI models.
+- [x] Prompt evaluation harness for routing and RL feedback.
+- [x] OpenRouter models configurable via environment variables.
+- [x] TikTok short-link domains (`vm.tiktok.com`, `vt.tiktok.com`) routed through multi-platform dispatcher.
 
 *Update this checklist whenever significant goals are finished or new tasks arise.*

--- a/src/ultimate_discord_intelligence_bot/config/agents.yaml
+++ b/src/ultimate_discord_intelligence_bot/config/agents.yaml
@@ -11,11 +11,12 @@ content_downloader:
   goal: Fetch media from supported platforms using specialised tools.
   backstory: >-
     You leverage yt-dlp to retrieve videos or streams from YouTube, Twitch,
-    Kick, Twitter and Instagram.
+    Kick, Twitter, Instagram, TikTok, Reddit and Discord.
 
 multi_platform_monitor:
   role: Multi-Platform Monitor
-  goal: Identify new content across YouTube, Twitch, Kick, Twitter, Instagram and Discord.
+  goal: Identify new content across YouTube, Twitch, Kick, Twitter, Instagram,
+    TikTok, Reddit and Discord.
   backstory: >-
     You watch platform feeds and report back only unseen items so downloads can
     be triggered when something fresh appears.

--- a/src/ultimate_discord_intelligence_bot/config/tasks.yaml
+++ b/src/ultimate_discord_intelligence_bot/config/tasks.yaml
@@ -9,14 +9,16 @@ process_video:
 execute_multi_platform_downloads:
   description: >-
     Retrieve media from a list of URLs spanning YouTube, Twitch, Kick,
-    Twitter and Instagram. Return metadata for each successful download.
+    Twitter, Instagram, TikTok, Reddit and Discord. Return metadata for each
+    successful download.
   expected_output: Local file paths and metadata for downloaded media.
   agent: content_downloader
 
 identify_new_content:
   description: >-
     Given candidate items from platform feeds (YouTube, Twitch, Kick, Twitter,
-    Instagram, Discord), return only those that have not been previously seen.
+    Instagram, TikTok, Reddit, Discord), return only those that have not been
+    previously seen.
   expected_output: List of new content items annotated with platform and URL.
   agent: multi_platform_monitor
 

--- a/src/ultimate_discord_intelligence_bot/services/__init__.py
+++ b/src/ultimate_discord_intelligence_bot/services/__init__.py
@@ -1,0 +1,15 @@
+"""Shared services for prompt engineering, routing and learning."""
+
+from .prompt_engine import PromptEngine
+from .openrouter_service import OpenRouterService
+from .learning_engine import LearningEngine
+from .memory_service import MemoryService
+from .evaluation_harness import EvaluationHarness
+
+__all__ = [
+    "PromptEngine",
+    "OpenRouterService",
+    "LearningEngine",
+    "MemoryService",
+    "EvaluationHarness",
+]

--- a/src/ultimate_discord_intelligence_bot/services/evaluation_harness.py
+++ b/src/ultimate_discord_intelligence_bot/services/evaluation_harness.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Prompt evaluation harness for benchmarking models.
+
+The :class:`EvaluationHarness` runs prompts across one or more models via the
+:class:`OpenRouterService`, recording latency, token usage and responses. Results
+are appended to a JSON Lines log so offline analysis and reinforcement learning
+can consume the data."""
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from .openrouter_service import OpenRouterService
+
+
+@dataclass
+class EvaluationHarness:
+    """Benchmark prompts across multiple models."""
+
+    router: OpenRouterService = field(default_factory=OpenRouterService)
+    log_path: str = "evaluation_log.jsonl"
+
+    def run(
+        self,
+        prompt: str,
+        task_type: str = "general",
+        models: List[str] | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Execute ``prompt`` against ``models`` and log the outcomes."""
+
+        models_to_run = models or self.router.models_map.get(
+            task_type, self.router.models_map["general"]
+        )
+        results: List[Dict[str, Any]] = []
+        for model in models_to_run:
+            start = time.perf_counter()
+            response = self.router.route(prompt, task_type=task_type, model=model)
+            latency = time.perf_counter() - start
+            record: Dict[str, Any] = {
+                "prompt": prompt,
+                "model": model,
+                "task_type": task_type,
+                "latency": latency,
+                **response,
+            }
+            results.append(record)
+            try:
+                with open(self.log_path, "a", encoding="utf-8") as fh:
+                    json.dump(record, fh)
+                    fh.write("\n")
+            except Exception:
+                pass
+        return results

--- a/src/ultimate_discord_intelligence_bot/services/learning_engine.py
+++ b/src/ultimate_discord_intelligence_bot/services/learning_engine.py
@@ -1,0 +1,57 @@
+"""Light-weight learning module for model selection.
+
+The :class:`LearningEngine` implements a simple epsilon-greedy multi-armed
+bandit strategy.  It records rewards for model choices on disk so future
+routing decisions can improve over time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class LearningEngine:
+    """Persisted epsilon-greedy learner for model routing."""
+
+    store_path: str = "learning_stats.json"
+    epsilon: float = 0.1
+    stats: Dict[str, Dict[str, Dict[str, float]]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if os.path.exists(self.store_path):  # pragma: no cover - startup
+            try:
+                with open(self.store_path, "r", encoding="utf-8") as fh:
+                    self.stats = json.load(fh)
+            except Exception:
+                self.stats = {}
+
+    def select_model(self, task: str, candidates: List[str]) -> str:
+        """Choose a model for ``task`` from ``candidates``."""
+        tstats = self.stats.setdefault(task, {})
+        for model in candidates:
+            tstats.setdefault(model, {"n": 0, "reward": 0.0})
+        if random.random() < self.epsilon:
+            return random.choice(candidates)
+        return max(
+            candidates,
+            key=lambda m: (
+                tstats[m]["reward"] / tstats[m]["n"] if tstats[m]["n"] else 0.0
+            ),
+        )
+
+    def update(self, task: str, model: str, reward: float) -> None:
+        """Record the observed ``reward`` for ``model`` in ``task``."""
+        tstats = self.stats.setdefault(task, {})
+        mstats = tstats.setdefault(model, {"n": 0, "reward": 0.0})
+        mstats["n"] += 1
+        mstats["reward"] += reward
+        try:  # pragma: no cover - disk I/O
+            with open(self.store_path, "w", encoding="utf-8") as fh:
+                json.dump(self.stats, fh)
+        except Exception:
+            pass

--- a/src/ultimate_discord_intelligence_bot/services/memory_service.py
+++ b/src/ultimate_discord_intelligence_bot/services/memory_service.py
@@ -1,0 +1,26 @@
+"""Simple in-memory retrieval service.
+
+The :class:`MemoryService` provides a minimal interface for storing and
+retrieving snippets of text.  It acts as a stand-in for a full vector database
+so components can integrate memory lookups without requiring heavy
+infrastructure during testing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class MemoryService:
+    """Store and retrieve small text memories."""
+
+    memories: List[Dict[str, str]] = field(default_factory=list)
+
+    def add(self, text: str, metadata: Dict[str, str] | None = None) -> None:
+        self.memories.append({"text": text, "metadata": metadata or {}})
+
+    def retrieve(self, query: str, limit: int = 5) -> List[Dict[str, str]]:
+        results = [m for m in self.memories if query.lower() in m["text"].lower()]
+        return results[:limit]

--- a/src/ultimate_discord_intelligence_bot/services/openrouter_service.py
+++ b/src/ultimate_discord_intelligence_bot/services/openrouter_service.py
@@ -1,0 +1,80 @@
+"""Dynamic model routing via the OpenRouter API.
+
+In production this service would query https://openrouter.ai to select a model
+and execute the request.  For testing and offline development we keep the
+implementation lightweight and fall back to a deterministic echo response when
+no API key is configured.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+import requests
+
+from .learning_engine import LearningEngine
+from .prompt_engine import PromptEngine
+
+
+class OpenRouterService:
+    """Route prompts to the best model and provider available."""
+
+    def __init__(
+        self,
+        models_map: Dict[str, List[str]] | None = None,
+        learning_engine: LearningEngine | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        # Environment variables allow deployment-time model overrides without
+        # changing source. ``OPENROUTER_GENERAL_MODEL`` sets the default model
+        # for unspecified task types while ``OPENROUTER_ANALYSIS_MODEL`` can
+        # specialise the analysis route.
+        env_general = os.getenv("OPENROUTER_GENERAL_MODEL")
+        env_analysis = os.getenv("OPENROUTER_ANALYSIS_MODEL")
+        default_map = {
+            "general": [env_general or "openai/gpt-3.5-turbo"],
+            "analysis": [env_analysis or env_general or "openai/gpt-3.5-turbo"],
+        }
+        if models_map:
+            default_map.update(models_map)
+        self.models_map = default_map
+        self.learning = learning_engine or LearningEngine()
+        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
+        self.prompt_engine = PromptEngine()
+
+    def _choose_model(self, task_type: str) -> str:
+        candidates = self.models_map.get(task_type) or self.models_map["general"]
+        return self.learning.select_model(task_type, candidates)
+
+    def route(self, prompt: str, task_type: str = "general", model: str | None = None) -> Dict[str, Any]:
+        """Send ``prompt`` to the selected model and return the response metadata."""
+        chosen = model or self._choose_model(task_type)
+        tokens = self.prompt_engine.count_tokens(prompt, chosen)
+        if not self.api_key:  # offline deterministic behaviour
+            response = prompt.upper()
+            self.learning.update(task_type, chosen, reward=1.0)
+            return {
+                "status": "success",
+                "model": chosen,
+                "response": response,
+                "tokens": tokens,
+            }
+        try:  # pragma: no cover - network call
+            resp = requests.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                json={"model": chosen, "messages": [{"role": "user", "content": prompt}]},
+                timeout=30,
+            )
+            data = resp.json()
+            message = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            self.learning.update(task_type, chosen, reward=1.0)
+            return {
+                "status": "success",
+                "model": chosen,
+                "response": message,
+                "tokens": tokens,
+            }
+        except Exception as exc:  # pragma: no cover - network failure
+            return {"status": "error", "error": str(exc), "model": chosen, "tokens": tokens}

--- a/src/ultimate_discord_intelligence_bot/services/prompt_engine.py
+++ b/src/ultimate_discord_intelligence_bot/services/prompt_engine.py
@@ -1,0 +1,77 @@
+"""Utilities for building prompts and counting tokens.
+
+The :class:`PromptEngine` centralises prompt construction and token counting so
+any agent, tool or workflow can consistently prepare requests for large
+language models. Token counting is provider aware: ``tiktoken`` powers OpenAI
+model estimates, ``transformers`` tokenizers cover other providers and a simple
+whitespace split acts as a final fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import tiktoken
+except Exception:  # pragma: no cover
+    tiktoken = None
+
+try:  # pragma: no cover - optional dependency
+    from transformers import AutoTokenizer  # type: ignore
+except Exception:  # pragma: no cover
+    AutoTokenizer = None
+
+
+@dataclass
+class PromptEngine:
+    """Generate prompts and estimate token usage."""
+
+    _tokenizers: Dict[str, Any] = field(default_factory=dict, init=False, repr=False)
+
+    def generate(self, template: str, variables: Dict[str, Any]) -> str:
+        """Fill ``template`` with ``variables`` using ``str.format``."""
+        return template.format(**variables)
+
+    def count_tokens(self, text: str, model: str | None = None) -> int:
+        """Return an estimated token count for ``text``.
+
+        Parameters
+        ----------
+        text:
+            The prompt text to analyse.
+        model:
+            Optional model name. When supplied the engine attempts to use a
+            provider-specific tokenizer: ``tiktoken`` for OpenAI models and
+            ``transformers`` for others. If no specialised tokenizer is
+            available a simple whitespace split provides a conservative
+            fallback.
+        """
+        if model:
+            if tiktoken:
+                try:
+                    enc = tiktoken.encoding_for_model(model)
+                    return len(enc.encode(text))
+                except Exception:
+                    pass
+            if AutoTokenizer:
+                try:
+                    tokenizer = self._tokenizers.get(model)
+                    if tokenizer is None:
+                        tokenizer = AutoTokenizer.from_pretrained(model)
+                        self._tokenizers[model] = tokenizer
+                    return len(tokenizer.encode(text))
+                except Exception:
+                    pass
+            if tiktoken:
+                enc = tiktoken.get_encoding("cl100k_base")
+                return len(enc.encode(text))
+        return len(text.split())
+
+    def optimise(self, prompt: str) -> str:
+        """Return a lightly normalised variant of ``prompt``.
+
+        This basic implementation simply strips surrounding whitespace; it can
+        be extended with more advanced optimisation strategies.
+        """
+        return prompt.strip()

--- a/src/ultimate_discord_intelligence_bot/tools/__init__.py
+++ b/src/ultimate_discord_intelligence_bot/tools/__init__.py
@@ -8,14 +8,17 @@ from .yt_dlp_download_tool import (
     KickDownloadTool,
     TwitterDownloadTool,
     InstagramDownloadTool,
+    TikTokDownloadTool,
+    RedditDownloadTool,
 )
+from .discord_download_tool import DiscordDownloadTool
+from .multi_platform_download_tool import MultiPlatformDownloadTool
 from .audio_transcription_tool import AudioTranscriptionTool
 from .discord_post_tool import DiscordPostTool
 from .drive_upload_tool import DriveUploadTool
 from .logical_fallacy_tool import LogicalFallacyTool
 from .memory_storage_tool import MemoryStorageTool
 from .perspective_synthesizer_tool import PerspectiveSynthesizerTool
-from .pipeline_tool import PipelineTool
 from .social_media_monitor_tool import SocialMediaMonitorTool
 from .multi_platform_monitor_tool import MultiPlatformMonitorTool
 from .x_monitor_tool import XMonitorTool
@@ -42,13 +45,16 @@ __all__ = [
     "KickDownloadTool",
     "TwitterDownloadTool",
     "InstagramDownloadTool",
+    "TikTokDownloadTool",
+    "RedditDownloadTool",
+    "DiscordDownloadTool",
+    "MultiPlatformDownloadTool",
     "AudioTranscriptionTool",
     "DiscordPostTool",
     "DriveUploadTool",
     "LogicalFallacyTool",
     "MemoryStorageTool",
     "PerspectiveSynthesizerTool",
-    "PipelineTool",
     "SocialMediaMonitorTool",
     "MultiPlatformMonitorTool",
     "XMonitorTool",

--- a/src/ultimate_discord_intelligence_bot/tools/discord_download_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/discord_download_tool.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Dict
+
+import requests
+from crewai_tools import BaseTool
+
+
+class DiscordDownloadTool(BaseTool):
+    """Download Discord-hosted attachments."""
+
+    name = "Discord Download Tool"
+    description = "Download Discord attachments"
+    platform = "Discord"
+
+    def _run(self, url: str, quality: str = "1080p") -> Dict[str, str]:
+        """Download a file from a Discord attachment URL."""
+        command_str = f"requests.get({url})"
+        try:
+            response = requests.get(url, stream=True, timeout=30)
+            response.raise_for_status()
+            suffix = os.path.splitext(url)[1]
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        tmp.write(chunk)
+                local_path = tmp.name
+            return {
+                "status": "success",
+                "platform": self.platform,
+                "local_path": local_path,
+                "command": command_str,
+            }
+        except Exception as exc:  # pragma: no cover - defensive path
+            return {
+                "status": "error",
+                "platform": self.platform,
+                "error": str(exc),
+                "command": command_str,
+            }
+
+    def run(self, url: str, quality: str = "1080p") -> Dict[str, str]:  # pragma: no cover - thin wrapper
+        return self._run(url, quality)

--- a/src/ultimate_discord_intelligence_bot/tools/multi_platform_download_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/multi_platform_download_tool.py
@@ -1,0 +1,74 @@
+"""Select the appropriate downloader based on URL domain."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Type
+from urllib.parse import urlparse
+
+from crewai_tools import BaseTool
+
+from .yt_dlp_download_tool import (
+    YtDlpDownloadTool,
+    YouTubeDownloadTool,
+    TwitchDownloadTool,
+    KickDownloadTool,
+    TwitterDownloadTool,
+    InstagramDownloadTool,
+    TikTokDownloadTool,
+    RedditDownloadTool,
+)
+from .discord_download_tool import DiscordDownloadTool
+
+
+class MultiPlatformDownloadTool(BaseTool):
+    """Dispatch to the correct platform downloader."""
+
+    name = "Multi-Platform Download Tool"
+    description = "Download media from supported platforms via yt-dlp"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._dispatch: Dict[str, Type[BaseTool]] = {
+            "youtube.com": YouTubeDownloadTool,
+            "youtu.be": YouTubeDownloadTool,
+            "twitch.tv": TwitchDownloadTool,
+            "kick.com": KickDownloadTool,
+            "twitter.com": TwitterDownloadTool,
+            "x.com": TwitterDownloadTool,
+            "instagram.com": InstagramDownloadTool,
+            # TikTok share links often use vm.tiktok.com or vt.tiktok.com aliases
+            "vm.tiktok.com": TikTokDownloadTool,
+            "vt.tiktok.com": TikTokDownloadTool,
+            "tiktok.com": TikTokDownloadTool,
+            "reddit.com": RedditDownloadTool,
+            "redd.it": RedditDownloadTool,
+            "v.redd.it": RedditDownloadTool,
+            "cdn.discordapp.com": DiscordDownloadTool,
+            "media.discordapp.net": DiscordDownloadTool,
+        }
+
+    def _run(self, url: str, quality: str = "1080p") -> Dict[str, Any]:
+        """Route ``url`` to the appropriate downloader.
+
+        Parameters
+        ----------
+        url:
+            Media link to fetch.
+        quality:
+            Preferred quality setting passed through to the underlying
+            platform tool. Defaults to ``1080p``.
+        """
+
+        domain = urlparse(url).netloc.lower()
+        for pattern, tool_cls in self._dispatch.items():
+            if domain.endswith(pattern):
+                return tool_cls().run(url, quality=quality)
+        return {
+            "status": "error",
+            "error": f"Unsupported platform for URL: {url}",
+            "platform": "unknown",
+        }
+
+    def run(self, url: str, quality: str = "1080p") -> Dict[str, Any]:  # pragma: no cover - thin wrapper
+        """Public wrapper delegating to :meth:`_run`."""
+        return self._run(url, quality=quality)

--- a/src/ultimate_discord_intelligence_bot/tools/perspective_synthesizer_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/perspective_synthesizer_tool.py
@@ -2,15 +2,43 @@
 
 from crewai_tools import BaseTool
 
+from ..services import MemoryService, OpenRouterService, PromptEngine
+
 
 class PerspectiveSynthesizerTool(BaseTool):
     name = "Perspective Synthesizer"
     description = "Merge multiple search backends into a unified summary"
 
+    def __init__(
+        self,
+        router: OpenRouterService | None = None,
+        prompt_engine: PromptEngine | None = None,
+        memory: MemoryService | None = None,
+    ) -> None:
+        super().__init__()
+        self.router = router or OpenRouterService()
+        self.prompt_engine = prompt_engine or PromptEngine()
+        self.memory = memory or MemoryService()
+
     def _run(self, *search_results) -> dict:
-        combined = "\n".join(str(r) for r in search_results if r)
-        return {"status": "success", "summary": combined.strip()}
+        combined = "\n".join(str(r) for r in search_results if r).strip()
+        if not combined:
+            return {"status": "success", "summary": ""}
+
+        memories = [m["text"] for m in self.memory.retrieve(combined)]
+        if memories:
+            combined = combined + "\n" + "\n".join(memories)
+
+        prompt = self.prompt_engine.generate(
+            "Summarise the following information:\n{content}", {"content": combined}
+        )
+        routed = self.router.route(prompt, task_type="analysis")
+        return {
+            "status": "success",
+            "summary": routed.get("response", combined),
+            "model": routed.get("model"),
+            "tokens": routed.get("tokens"),
+        }
 
     def run(self, *args, **kwargs):  # pragma: no cover
         return self._run(*args, **kwargs)
-

--- a/src/ultimate_discord_intelligence_bot/tools/pipeline_tool.py
+++ b/src/ultimate_discord_intelligence_bot/tools/pipeline_tool.py
@@ -8,9 +8,9 @@ class PipelineTool(BaseTool):
     name: str = "Content Pipeline Tool"
     description: str = "Download, transcribe, analyse and post a video to Discord."
 
-    def _run(self, url: str) -> dict:
+    def _run(self, url: str, quality: str = "1080p") -> dict:
         pipeline = ContentPipeline()
-        return asyncio.run(pipeline.process_video(url))
+        return asyncio.run(pipeline.process_video(url, quality=quality))
 
     # Expose run for CrewAI compatibility
     def run(self, *args, **kwargs):  # pragma: no cover - thin wrapper

--- a/tests/test_evaluation_harness.py
+++ b/tests/test_evaluation_harness.py
@@ -1,0 +1,29 @@
+import json
+
+from ultimate_discord_intelligence_bot.services.evaluation_harness import (
+    EvaluationHarness,
+)
+
+
+def test_evaluation_harness_logs_results(tmp_path, monkeypatch):
+    log_file = tmp_path / "log.jsonl"
+    harness = EvaluationHarness()
+    harness.log_path = str(log_file)
+
+    def fake_route(prompt, task_type="general", model=None):
+        return {
+            "status": "success",
+            "model": model,
+            "response": prompt.upper(),
+            "tokens": len(prompt.split()),
+        }
+
+    monkeypatch.setattr(harness.router, "route", fake_route)
+    results = harness.run("hello world", models=["a", "b"])
+    assert len(results) == 2
+    lines = log_file.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first["model"] == "a"
+    assert first["tokens"] == 2
+    assert "latency" in first

--- a/tests/test_multi_platform_download_dispatcher.py
+++ b/tests/test_multi_platform_download_dispatcher.py
@@ -1,0 +1,86 @@
+import pytest
+
+from ultimate_discord_intelligence_bot.tools.multi_platform_download_tool import (
+    MultiPlatformDownloadTool,
+)
+from ultimate_discord_intelligence_bot.tools.yt_dlp_download_tool import (
+    YouTubeDownloadTool,
+    TwitchDownloadTool,
+    KickDownloadTool,
+    TwitterDownloadTool,
+    InstagramDownloadTool,
+    TikTokDownloadTool,
+    RedditDownloadTool,
+)
+from ultimate_discord_intelligence_bot.tools.discord_download_tool import (
+    DiscordDownloadTool,
+)
+
+
+@pytest.mark.parametrize(
+    "url,tool_cls",
+    [
+        ("https://www.youtube.com/watch?v=1", YouTubeDownloadTool),
+        ("https://youtu.be/1", YouTubeDownloadTool),
+        ("https://www.twitch.tv/videos/1", TwitchDownloadTool),
+        ("https://kick.com/video/1", KickDownloadTool),
+        ("https://twitter.com/user/status/1", TwitterDownloadTool),
+        ("https://x.com/user/status/1", TwitterDownloadTool),
+        ("https://www.instagram.com/reel/1", InstagramDownloadTool),
+        ("https://www.tiktok.com/@user/video/1", TikTokDownloadTool),
+        ("https://vm.tiktok.com/ZM1/", TikTokDownloadTool),
+        ("https://vt.tiktok.com/ZM2/", TikTokDownloadTool),
+        ("https://www.reddit.com/r/videos/comments/1/demo/", RedditDownloadTool),
+        (
+            "https://cdn.discordapp.com/attachments/1/2/video.mp4",
+            DiscordDownloadTool,
+        ),
+    ],
+)
+def test_dispatcher_selects_tool(monkeypatch, url, tool_cls):
+    tool = MultiPlatformDownloadTool()
+    called = {}
+
+    def fake_run(self, url_arg, quality="1080p"):
+        called["tool"] = self.platform
+        called["quality"] = quality
+        return {
+            "status": "success",
+            "platform": self.platform,
+            "command": "yt-dlp stub",
+        }
+
+    monkeypatch.setattr(tool_cls, "run", fake_run)
+    result = tool.run(url)
+    assert called["tool"] == tool_cls.platform
+    assert called["quality"] == "1080p"
+    assert result["platform"] == tool_cls.platform
+    assert result["command"] == "yt-dlp stub"
+
+
+def test_dispatcher_forwards_quality(monkeypatch):
+    tool = MultiPlatformDownloadTool()
+    called = {}
+
+    def fake_run(self, url_arg, quality="1080p"):
+        called["tool"] = self.platform
+        called["quality"] = quality
+        return {
+            "status": "success",
+            "platform": self.platform,
+            "command": "yt-dlp stub",
+        }
+
+    monkeypatch.setattr(YouTubeDownloadTool, "run", fake_run)
+    url = "https://www.youtube.com/watch?v=1"
+    tool.run(url, quality="720p")
+    assert called["tool"] == "YouTube"
+    assert called["quality"] == "720p"
+
+
+def test_dispatcher_reports_unsupported_url():
+    tool = MultiPlatformDownloadTool()
+    result = tool.run("https://example.com/video/1")
+    assert result["status"] == "error"
+    assert "Unsupported platform" in result["error"]
+    assert result["platform"] == "unknown"

--- a/tests/test_multi_platform_download_tools.py
+++ b/tests/test_multi_platform_download_tools.py
@@ -1,32 +1,179 @@
+import json
 import subprocess
 
 import pytest
+import requests
 
 from ultimate_discord_intelligence_bot.tools.yt_dlp_download_tool import (
+    YouTubeDownloadTool,
     TwitchDownloadTool,
     KickDownloadTool,
     TwitterDownloadTool,
     InstagramDownloadTool,
+    TikTokDownloadTool,
+    RedditDownloadTool,
+)
+from ultimate_discord_intelligence_bot.tools.discord_download_tool import (
+    DiscordDownloadTool,
 )
 
 
 @pytest.mark.parametrize(
     "tool_cls",
-    [TwitchDownloadTool, KickDownloadTool, TwitterDownloadTool, InstagramDownloadTool],
+    [
+        YouTubeDownloadTool,
+        TwitchDownloadTool,
+        KickDownloadTool,
+        TwitterDownloadTool,
+        InstagramDownloadTool,
+        TikTokDownloadTool,
+        RedditDownloadTool,
+    ],
 )
 def test_downloader_reports_platform(monkeypatch, tool_cls):
     def fake_run(cmd, capture_output, text, timeout, env):
         class Result:
             returncode = 0
-            stdout = "id|title|uploader|10|100|/tmp/uploader/title [id].mp4\n"
+            stdout = json.dumps(
+                {
+                    "id": "id",
+                    "title": "title",
+                    "uploader": "uploader",
+                    "duration": 10,
+                    "filesize_approx": 100,
+                    "filepath": "/tmp/uploader/title [id].mp4",
+                }
+            ) + "\n"
             stderr = ""
 
         return Result()
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     tool = tool_cls()
-    result = tool._run("http://example.com")
+    result = tool.run("http://example.com")
     assert result["platform"] == tool.platform
     assert result["status"] == "success"
     assert result["local_path"].endswith("title [id].mp4")
+    assert result["command"].startswith("yt-dlp")
+
+
+def test_downloader_handles_malformed_output(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout, env):
+        class Result:
+            returncode = 0
+            stdout = "unexpected"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    tool = TikTokDownloadTool()
+    result = tool.run("http://example.com")
+    assert result["status"] == "error"
+    assert "Unexpected yt-dlp output" in result["error"]
+
+
+def test_downloader_reports_subprocess_error(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout, env):
+        class Result:
+            returncode = 1
+            stdout = ""
+            stderr = "boom\n"
+
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    tool = TikTokDownloadTool()
+    result = tool.run("http://example.com")
+    assert result["status"] == "error"
+    assert result["error"] == "boom"
+    assert result["command"].startswith("yt-dlp")
+
+
+def test_downloader_reports_timeout(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout, env):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    tool = TikTokDownloadTool()
+    result = tool.run("http://example.com")
+    assert result["status"] == "error"
+    assert result["error"] == "Download timeout after 30 minutes"
+    assert result["command"].startswith("yt-dlp")
+
+
+def test_downloader_reports_unhandled_exception(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout, env):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    tool = TikTokDownloadTool()
+    result = tool.run("http://example.com")
+    assert result["status"] == "error"
+    assert result["error"] == "boom"
+    assert result["command"].startswith("yt-dlp")
+
+
+def test_downloader_honors_quality(monkeypatch):
+    captured: dict = {}
+
+    def fake_run(cmd, capture_output, text, timeout, env):
+        captured["cmd"] = cmd
+        class Result:
+            returncode = 0
+            stdout = json.dumps(
+                {
+                    "id": "id",
+                    "title": "title",
+                    "uploader": "uploader",
+                    "duration": 10,
+                    "filesize_approx": 100,
+                    "filepath": "/tmp/uploader/title [id].mp4",
+                }
+            ) + "\n"
+            stderr = ""
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    tool = YouTubeDownloadTool()
+    tool.run("http://example.com", quality="480p")
+    assert "-f" in captured["cmd"]
+    fmt = captured["cmd"][captured["cmd"].index("-f") + 1]
+    assert "height<=480" in fmt
+
+
+def test_discord_downloader_reports_platform(monkeypatch):
+    def fake_get(url, stream=True, timeout=30):
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def iter_content(self, chunk_size):
+                yield b"data"
+
+        return Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    tool = DiscordDownloadTool()
+    result = tool.run("https://cdn.discordapp.com/attachments/1/2/video.mp4")
+    assert result["status"] == "success"
+    assert result["platform"] == "Discord"
+    assert result["local_path"].endswith(".mp4")
+    assert result["command"].startswith("requests.get")
+
+
+def test_discord_downloader_reports_http_error(monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            raise requests.HTTPError("boom")
+
+    def fake_get(url, stream=True, timeout=30):
+        return Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    tool = DiscordDownloadTool()
+    result = tool.run("https://cdn.discordapp.com/attachments/1/2/video.mp4")
+    assert result["status"] == "error"
+    assert result["error"] == "boom"
+    assert result["command"].startswith("requests.get")
 

--- a/tests/test_perspective_synthesizer_tool.py
+++ b/tests/test_perspective_synthesizer_tool.py
@@ -1,8 +1,22 @@
-from ultimate_discord_intelligence_bot.tools.perspective_synthesizer_tool import PerspectiveSynthesizerTool
+from ultimate_discord_intelligence_bot.tools.perspective_synthesizer_tool import (
+    PerspectiveSynthesizerTool,
+)
+from ultimate_discord_intelligence_bot.services import MemoryService
 
 
-def test_combines_inputs():
+def test_combines_inputs(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     tool = PerspectiveSynthesizerTool()
     result = tool._run("A", "B")
     assert result["status"] == "success"
-    assert result["summary"] == "A\nB"
+    expected = ("Summarise the following information:\nA\nB").upper()
+    assert result["summary"] == expected
+
+
+def test_retrieves_memory(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    memory = MemoryService()
+    memory.add("extra context")
+    tool = PerspectiveSynthesizerTool(memory=memory)
+    result = tool._run("extra")
+    assert "EXTRA CONTEXT" in result["summary"]

--- a/tests/test_pipeline_tool.py
+++ b/tests/test_pipeline_tool.py
@@ -1,0 +1,23 @@
+from ultimate_discord_intelligence_bot.tools.pipeline_tool import PipelineTool
+
+
+def test_pipeline_tool_passes_quality(monkeypatch):
+    called = {}
+
+    class DummyPipeline:
+        async def process_video(self, url: str, quality: str = "1080p"):
+            called["url"] = url
+            called["quality"] = quality
+            return {"status": "success"}
+
+    monkeypatch.setattr(
+        "ultimate_discord_intelligence_bot.tools.pipeline_tool.ContentPipeline",
+        DummyPipeline,
+    )
+
+    tool = PipelineTool()
+    result = tool.run("http://example.com", quality="720p")
+
+    assert result["status"] == "success"
+    assert called == {"url": "http://example.com", "quality": "720p"}
+

--- a/tests/test_prompt_and_routing_services.py
+++ b/tests/test_prompt_and_routing_services.py
@@ -1,0 +1,85 @@
+import os
+
+import pytest
+
+from ultimate_discord_intelligence_bot.services import (
+    LearningEngine,
+    MemoryService,
+    OpenRouterService,
+    PromptEngine,
+)
+from ultimate_discord_intelligence_bot.tools import PerspectiveSynthesizerTool
+
+
+def test_prompt_engine_counts_tokens():
+    engine = PromptEngine()
+    text = "hello world"
+    count = engine.count_tokens(text, model="gpt-3.5-turbo")
+    assert isinstance(count, int) and count > 0
+
+
+def test_prompt_engine_uses_transformers(monkeypatch):
+    engine = PromptEngine()
+
+    class DummyTokenizer:
+        def encode(self, text: str):
+            return [0, 1, 2]
+
+    class DummyAutoTokenizer:
+        @staticmethod
+        def from_pretrained(name: str):  # pragma: no cover - simple stub
+            return DummyTokenizer()
+
+    monkeypatch.setattr(
+        "ultimate_discord_intelligence_bot.services.prompt_engine.AutoTokenizer",
+        DummyAutoTokenizer,
+    )
+    monkeypatch.setattr(
+        "ultimate_discord_intelligence_bot.services.prompt_engine.tiktoken",
+        None,
+    )
+    count = engine.count_tokens("hello", model="dummy-model")
+    assert count == 3
+
+
+def test_memory_service_store_and_retrieve():
+    memory = MemoryService()
+    memory.add("The sky is blue", {"source": "test"})
+    assert memory.retrieve("sky") == [{"text": "The sky is blue", "metadata": {"source": "test"}}]
+
+
+def test_learning_engine_updates(tmp_path):
+    store = tmp_path / "stats.json"
+    learner = LearningEngine(store_path=str(store), epsilon=0.0)
+    model = learner.select_model("task", ["a", "b"])
+    assert model in {"a", "b"}
+    learner.update("task", model, reward=2.0)
+    learner2 = LearningEngine(store_path=str(store), epsilon=0.0)
+    assert learner2.stats["task"][model]["reward"] == 2.0
+
+
+def test_openrouter_service_offline_routing(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    router = OpenRouterService(models_map={"analysis": ["model-a"]})
+    result = router.route("test", task_type="analysis")
+    assert result["model"] == "model-a"
+    assert result["response"] == "TEST"
+
+
+def test_openrouter_env_model_override(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_GENERAL_MODEL", "env-model")
+    router = OpenRouterService()
+    result = router.route("hi")
+    assert result["model"] == "env-model"
+
+
+def test_perspective_synthesizer_integration(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    tool = PerspectiveSynthesizerTool()
+    out = tool.run("piece one", "piece two")
+    expected = (
+        "Summarise the following information:\n" "piece one\n" "piece two"
+    ).upper()
+    assert out["summary"] == expected
+    assert out["model"]

--- a/tests/test_youtube_download_tool.py
+++ b/tests/test_youtube_download_tool.py
@@ -1,13 +1,27 @@
+import json
 import subprocess
-from ultimate_discord_intelligence_bot.tools.youtube_download_tool import YouTubeDownloadTool
+
+from ultimate_discord_intelligence_bot.tools.youtube_download_tool import (
+    YouTubeDownloadTool,
+)
 
 
 def test_youtube_download_parses_filepath(monkeypatch):
     def fake_run(cmd, capture_output, text, timeout, env):
         class Result:
             returncode = 0
-            stdout = "id|title|uploader|10|100|/tmp/uploader/title [id].mp4\n"
+            stdout = json.dumps(
+                {
+                    "id": "id",
+                    "title": "title",
+                    "uploader": "uploader",
+                    "duration": 10,
+                    "filesize_approx": 100,
+                    "filepath": "/tmp/uploader/title [id].mp4",
+                }
+            ) + "\n"
             stderr = ""
+
         return Result()
 
     monkeypatch.setattr(subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary
- introduce prompt engine with provider-aware token counting
- add OpenRouter-driven model router with epsilon-greedy learning engine
- extend yt-dlp suite with TikTokDownloadTool and multi-platform dispatch coverage
- document TikTok short-link routing in progress tracker

## Testing
- `pytest -q`

## Progress Tracker
- [x] Prompt engine and token counter service available globally
- [x] OpenRouter-based model router with learning feedback
- [x] TikTok downloader integrated into multi-platform dispatcher
- [x] TikTok short-link domains routed via dispatcher
- [x] Tests covering TikTok downloads and dispatch


------
https://chatgpt.com/codex/tasks/task_e_68ac3c6dc6dc832ea3a72637635c1a47