### PR TITLE
feat(archiver): persist attachment metadata

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -38,6 +38,17 @@
 - [x] retention sweeper & export tool
 - [ ] Discord ops privacy commands
 
+## PR7 – Discord CDN Archiver (future-proof)
+- [x] router + routes config
+- [x] policy layer + EXIF redaction
+- [x] limits detection
+- [x] compressors and segmenting stubs
+- [x] uploader with retries
+- [x] manifest with dedup & compression params
+- [x] rehydrate helpers
+- [x] REST façade + CLI
+- [x] basic tests & docs
+
 | Phase | Item | Status | Notes |
 |------:|------|:------:|-------|
 | PR2 | Adapters (YT/Twitch + fixtures) | ✅ | |
@@ -59,3 +70,12 @@
 | PR5 | provenance + usage_log schema and writes | ✅ | |
 | PR5 | retention sweeper + export tool | ✅ | |
 | PR5 | ops commands + alerts | ☐ | alerts pending |
+| PR7 | manifest stores attachment ids + compression | ✅ | |
+
+## PR18 – Security Hardening, Secrets, RBAC & Abuse Prevention
+- [x] RBAC module and YAML permissions
+- [x] Network guard blocking private hosts
+- [x] In-memory token bucket rate limiter
+- [x] Security docs and baseline config
+- [x] Input validation helpers for URLs and file paths
+- [x] Basic content moderation helper

--- a/config/security.yaml
+++ b/config/security.yaml
@@ -1,0 +1,16 @@
+role_permissions:
+  viewer: []
+  user: []
+  moderator:
+    - security.view
+  ops:
+    - security.view
+    - ingest.backfill
+  admin:
+    - "*"
+rate_limits:
+  default_per_minute: 60
+moderation:
+  banned_terms:
+    - banned
+  action: redact

--- a/docs/archiver.md
+++ b/docs/archiver.md
@@ -3,8 +3,9 @@
 The archiver stores project artifacts in Discord and keeps enough metadata to
 re‑fetch them when CDN links expire. Discord’s default per‑attachment upload
 limit is roughly **10 MiB** unless a server’s boost tier raises it. Because CDN
-links are temporary and signed, the manifest records the message and attachment
-IDs instead of raw URLs.
+links are temporary and signed, the manifest records the message ID and all
+attachment IDs instead of raw URLs. Compression parameters are persisted so
+future re‑uploads can avoid double re‑encoding.
 
 ## Limit Detection and Policy
 

--- a/docs/security/config.md
+++ b/docs/security/config.md
@@ -1,0 +1,21 @@
+# Security Configuration
+
+The file `config/security.yaml` defines role permissions, basic rate limits, and
+simple moderation rules.
+
+Example:
+
+```yaml
+role_permissions:
+  viewer: []
+  ops:
+    - ingest.backfill
+  admin:
+    - '*'
+rate_limits:
+  default_per_minute: 60
+moderation:
+  banned_terms:
+    - banned
+  action: redact
+```

--- a/docs/security/moderation.md
+++ b/docs/security/moderation.md
@@ -1,0 +1,20 @@
+# Content Moderation
+
+The `security.moderation` helper provides a minimal rule-based filter for user
+and model text. Banned terms are configured in `config/security.yaml` and may
+be redacted or blocked entirely.
+
+Example:
+
+```python
+from security.moderation import Moderation
+
+mod = Moderation()
+result = mod.check("bad word here")
+if result.action == "block":
+    raise ValueError("content not allowed")
+text = result.text  # contains redactions when action == "redact"
+```
+
+This layer is intentionally simple; integrate with external moderation services
+or LLM-based classifiers where needed.

--- a/docs/security/ops.md
+++ b/docs/security/ops.md
@@ -1,0 +1,30 @@
+# Security Operations
+
+This repository includes basic role-based access control and rate limiting helpers.
+
+## RBAC
+
+Use the :class:`security.rbac.RBAC` class to verify permissions. Decorate callables with
+``@rbac.require('perm')`` and call them with a ``roles`` keyword argument.
+
+## Rate limiting
+
+The :class:`security.rate_limit.TokenBucket` class offers a simple in-memory token bucket
+that can be used to throttle abusive callers.
+
+## Network guard
+
+Use :func:`security.net_guard.is_safe_url` before making outbound requests to
+ensure URLs use public hosts and approved schemes.
+
+## Secrets
+
+Load credentials from environment variables using
+``security.secrets.get_secret``. Use ``rotate_secret`` after rotating the
+underlying value to refresh the in-memory cache.
+
+## Moderation
+
+The :class:`security.moderation.Moderation` helper scans text for banned
+terms defined in ``config/security.yaml``. Depending on the configured action it
+will redact or block offending content.

--- a/docs/security/secrets.md
+++ b/docs/security/secrets.md
@@ -1,0 +1,17 @@
+# Secrets Management
+
+Use the `security.secrets` helpers to load secrets from environment variables
+with optional versioning. A reference such as `OPENAI_KEY:v2` maps to the
+environment variable `OPENAI_KEY_V2`.
+
+## Basic usage
+```python
+from security.secrets import get_secret, rotate_secret
+
+key = get_secret("OPENAI_KEY:v2")
+# ... later after rotating the key in the environment
+new_key = rotate_secret("OPENAI_KEY:v2")
+```
+
+The helpers cache values in-memory to avoid repeated lookups. Calling
+`rotate_secret` clears the cache for a reference and returns the fresh value.

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -1,0 +1,6 @@
+# Threat Model
+
+This project considers threats such as unauthorized access to privileged commands,
+server-side request forgery and abuse via excessive requests. Mitigations include
+role-based access controls, a network guard to block private addresses, and an
+in-memory token bucket rate limiter.

--- a/docs/security/validation.md
+++ b/docs/security/validation.md
@@ -1,0 +1,16 @@
+# Input Validation
+
+The `src.security.validate` module provides helpers to reject unsafe inputs
+before they reach sensitive parts of the system.
+
+## URL checks
+Use `validate_url` to ensure a URL uses HTTP(S) and resolves to a public host.
+
+## File names and paths
+`validate_filename` rejects names containing path separators or traversal
+components. Combine it with `validate_path` to keep file operations confined to
+an expected base directory.
+
+## MIME consistency
+`validate_mime` verifies the provided MIME type matches what the filename
+suggests. This guards against disguised executables.

--- a/src/archive/discord_store/api.py
+++ b/src/archive/discord_store/api.py
@@ -42,7 +42,6 @@ def archive_file(
     sha256 = manifest.compute_hash(fitted_path)
     existing = manifest.lookup(sha256)
     if existing:
-        existing["tags"] = existing.get("tags", "").split(",") if existing.get("tags") else []
         existing["content_hash"] = sha256
         if not keep_local:
             cleanup.delete(path)
@@ -56,7 +55,7 @@ def archive_file(
     record = {
         "message_id": str(upload_resp.get("id", "0")),
         "channel_id": channel_id,
-        "attachment_id": str(upload_resp.get("attachments", [{}])[0].get("id", "0")),
+        "attachment_ids": [str(a.get("id", "0")) for a in upload_resp.get("attachments", [])],
         "filename": Path(fitted_path).name,
         "size": stats["final_size"],
         "sha256": sha256,
@@ -65,6 +64,7 @@ def archive_file(
         "media_type": kind,
         "visibility": visibility,
         "tags": meta.get("tags", []),
+        "compression": stats,
     }
     manifest.record(sha256, record)
     if not keep_local:

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,26 @@
+"""Security utilities for the Crew repository."""
+
+from .rbac import RBAC
+from .net_guard import is_safe_url
+from .rate_limit import TokenBucket
+from .secrets import get_secret, rotate_secret
+from .validate import (
+    validate_url,
+    validate_filename,
+    validate_path,
+    validate_mime,
+)
+from .moderation import Moderation
+
+__all__ = [
+    "RBAC",
+    "is_safe_url",
+    "TokenBucket",
+    "get_secret",
+    "rotate_secret",
+    "validate_url",
+    "validate_filename",
+    "validate_path",
+    "validate_mime",
+    "Moderation",
+]

--- a/src/security/moderation.py
+++ b/src/security/moderation.py
@@ -1,0 +1,56 @@
+"""Simple content moderation utilities."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+import yaml
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "security.yaml"
+
+
+@dataclass
+class ModerationResult:
+    action: str
+    text: str
+
+
+class Moderation:
+    """Rule-based moderation checker using banned terms."""
+
+    def __init__(
+        self,
+        banned_terms: List[str] | None = None,
+        action: str | None = None,
+        config_path: Path | None = None,
+    ) -> None:
+        self._config_path = config_path or DEFAULT_CONFIG_PATH
+        if banned_terms is None or action is None:
+            data = self._load()
+            banned_terms = banned_terms or data.get("banned_terms", [])
+            action = action or data.get("action", "block")
+        self.banned_terms = [t.lower() for t in banned_terms]
+        self.action = action
+
+    def _load(self) -> dict:
+        if not self._config_path.exists():
+            return {}
+        data = yaml.safe_load(self._config_path.read_text()) or {}
+        return data.get("moderation", {})
+
+    def check(self, text: str) -> ModerationResult:
+        lowered = text.lower()
+        found = False
+        cleaned = text
+        for term in self.banned_terms:
+            if term in lowered:
+                found = True
+                if self.action == "redact":
+                    pattern = re.compile(re.escape(term), re.IGNORECASE)
+                    cleaned = pattern.sub("[redacted]", cleaned)
+        if not found:
+            return ModerationResult("allow", text)
+        if self.action == "redact":
+            return ModerationResult("redact", cleaned)
+        return ModerationResult("block", text)

--- a/src/security/net_guard.py
+++ b/src/security/net_guard.py
@@ -1,0 +1,58 @@
+"""Utilities to guard against unsafe network requests.
+
+The helpers here perform lightweight URL validation to reduce the risk of
+server-side request forgery (SSRF). Only basic checks are performed; callers
+should layer additional validation as needed for their context.
+"""
+from __future__ import annotations
+
+from urllib.parse import urlparse
+import ipaddress
+import socket
+
+
+def _resolve_host(host: str) -> list[str]:
+    """Resolve ``host`` to all IP addresses (IPv4 and IPv6).
+
+    Returns an empty list if resolution fails. A domain may resolve to multiple
+    addresses; the caller must treat the host as unsafe if *any* resolved
+    address is private.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return []
+    return list({info[4][0] for info in infos})
+
+
+def _is_private(host: str) -> bool:
+    """Return ``True`` if ``host`` resolves to any non-public IP."""
+    try:
+        ips = [ipaddress.ip_address(host)]
+    except ValueError:
+        resolved = _resolve_host(host)
+        if not resolved:
+            return True
+        ips = [ipaddress.ip_address(ip) for ip in resolved]
+    for ip in ips:
+        if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_multicast:
+            return True
+    return False
+
+
+def is_safe_url(url: str, allowed_schemes: set[str] | None = None) -> bool:
+    """Return True if ``url`` uses a public host and allowed scheme."""
+    allowed_schemes = allowed_schemes or {"http", "https"}
+    url = url.strip()
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+    if parsed.scheme not in allowed_schemes:
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+    if _is_private(host):
+        return False
+    return True

--- a/src/security/rate_limit.py
+++ b/src/security/rate_limit.py
@@ -1,0 +1,51 @@
+"""Simple in-memory token bucket rate limiter.
+
+The :class:`TokenBucket` class implements a coarse in-memory token bucket
+algorithm. Each ``key`` has its own bucket with the same rate and
+capacity. The implementation is intentionally lightweight so it can be used
+in tests or small utilities without external dependencies. It is not meant
+for distributed rate limiting.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class TokenBucket:
+    """An in-memory token bucket.
+
+    Parameters
+    ----------
+    rate:
+        Number of tokens added to each bucket per second.
+    capacity:
+        Maximum number of tokens a bucket can hold.
+    """
+
+    rate: float
+    capacity: int
+    _tokens: Dict[str, float] = field(default_factory=dict)
+    _timestamps: Dict[str, float] = field(default_factory=dict)
+
+    def allow(self, key: str, tokens: float = 1.0) -> bool:
+        """Return ``True`` if ``key`` may consume ``tokens`` now.
+
+        ``tokens`` must be positive; fractional tokens are permitted to
+        represent sub-requests.
+        """
+        if tokens <= 0:
+            raise ValueError("tokens must be positive")
+
+        now = time.monotonic()
+        tokens_left = self._tokens.get(key, self.capacity)
+        last = self._timestamps.get(key, now)
+        tokens_left = min(self.capacity, tokens_left + (now - last) * self.rate)
+        allowed = tokens_left >= tokens
+        if allowed:
+            tokens_left -= tokens
+        self._tokens[key] = tokens_left
+        self._timestamps[key] = now
+        return allowed

--- a/src/security/rbac.py
+++ b/src/security/rbac.py
@@ -1,0 +1,66 @@
+"""Role based access control helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Callable, Any, Dict, Set
+import functools
+import yaml
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "security.yaml"
+
+
+class RBAC:
+    """Simple RBAC checker backed by a YAML config."""
+
+    def __init__(
+        self,
+        role_permissions: Dict[str, Set[str]] | None = None,
+        config_path: Path | None = None,
+    ) -> None:
+        """Create an :class:`RBAC` instance.
+
+        Parameters
+        ----------
+        role_permissions:
+            Optional in-memory map of roles to permission strings. When
+            ``None`` the mapping is loaded from ``config_path``.
+        config_path:
+            Path to the YAML configuration file. Defaults to
+            ``config/security.yaml`` within the repository.
+        """
+
+        self._config_path = config_path or DEFAULT_CONFIG_PATH
+        if role_permissions is None:
+            role_permissions = self._load()
+        self.role_permissions: Dict[str, Set[str]] = role_permissions
+
+    def _load(self) -> Dict[str, Set[str]]:
+        """Load role permissions from ``self._config_path``."""
+        if not self._config_path.exists():
+            return {}
+        data = yaml.safe_load(self._config_path.read_text()) or {}
+        return {role: set(perms) for role, perms in (data.get("role_permissions") or {}).items()}
+
+    def has_perm(self, roles: Iterable[str], perm: str) -> bool:
+        """Return ``True`` if any role grants ``perm``."""
+        for role in roles:
+            perms = self.role_permissions.get(role, set())
+            if "*" in perms or perm in perms:
+                return True
+        return False
+
+    def require(self, perm: str) -> Callable:
+        """Decorator enforcing ``perm`` based on a ``roles`` kwarg."""
+
+        def decorator(func: Callable) -> Callable:
+            @functools.wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                roles = kwargs.get("roles", [])
+                if not self.has_perm(roles, perm):
+                    raise PermissionError(f"missing permission '{perm}'")
+                kwargs.pop("roles", None)
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator

--- a/src/security/secrets.py
+++ b/src/security/secrets.py
@@ -1,0 +1,71 @@
+"""Utilities for accessing secrets with optional versioning and caching.
+
+Secrets are read from environment variables and cached in-memory to avoid
+repeated lookups. A secret reference may include an optional version suffix
+separated by a colon, e.g. ``OPENAI_KEY:v2`` maps to the environment variable
+``OPENAI_KEY_V2``.
+
+Examples
+--------
+>>> import os
+>>> from security.secrets import get_secret, rotate_secret
+>>> os.environ['DEMO_TOKEN_V1'] = 'one'
+>>> get_secret('DEMO_TOKEN:v1')
+'one'
+>>> os.environ['DEMO_TOKEN_V1'] = 'two'
+>>> get_secret('DEMO_TOKEN:v1')  # cached
+'one'
+>>> rotate_secret('DEMO_TOKEN:v1')
+'two'
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+_cache: Dict[str, str] = {}
+
+
+def _env_key(ref: str) -> str:
+    name, _, version = ref.partition(":")
+    key = name
+    if version:
+        key = f"{name}_{version}"
+    return key.upper().replace("-", "_")
+
+
+def get_secret(ref: str) -> str:
+    """Return the secret value for ``ref``.
+
+    Parameters
+    ----------
+    ref:
+        Secret reference in the form ``NAME`` or ``NAME:version``.
+
+    Raises
+    ------
+    KeyError
+        If the corresponding environment variable is not set.
+    """
+
+    key = _env_key(ref)
+    if key in _cache:
+        return _cache[key]
+    try:
+        value = os.environ[key]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise KeyError(f"Missing secret: {key}") from exc
+    _cache[key] = value
+    return value
+
+
+def rotate_secret(ref: str) -> str:
+    """Refresh and return the secret value for ``ref``.
+
+    This clears any cached value and re-reads from the environment.
+    """
+
+    key = _env_key(ref)
+    _cache.pop(key, None)
+    return get_secret(ref)

--- a/src/security/validate.py
+++ b/src/security/validate.py
@@ -1,0 +1,55 @@
+"""Input validation utilities.
+
+Provides helpers to validate URLs, file names, MIME types, and file paths
+before using them. These helpers raise ``ValueError`` on invalid inputs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import mimetypes
+import os
+
+from . import net_guard
+
+
+def validate_url(url: str) -> str:
+    """Return ``url`` if safe, else raise ``ValueError``.
+
+    Checks scheme and ensures the host is public using ``net_guard``.
+    """
+    if not net_guard.is_safe_url(url):
+        raise ValueError("unsafe url")
+    return url
+
+
+def validate_filename(name: str) -> str:
+    """Return ``name`` if it contains no path separators or traversal parts."""
+    if not name or os.path.basename(name) != name or name in {"..", "."}:
+        raise ValueError("invalid filename")
+    if any(part in {"..", ""} for part in Path(name).parts):
+        raise ValueError("invalid filename")
+    return name
+
+
+def validate_path(path: str | Path, base: str | Path) -> Path:
+    """Join ``path`` to ``base`` and ensure the result stays within ``base``.
+
+    Returns the resolved ``Path`` on success.
+    """
+    base_path = Path(base).resolve()
+    resolved = (base_path / Path(path)).resolve()
+    try:
+        resolved.relative_to(base_path)
+    except ValueError:
+        raise ValueError("path traversal detected")
+    return resolved
+
+
+def validate_mime(filename: str, mime: str | None) -> None:
+    """Validate that ``mime`` matches the guessed type for ``filename``.
+
+    Raises ``ValueError`` if ``mime`` is present and mismatched.
+    """
+    guessed, _ = mimetypes.guess_type(filename)
+    if mime and guessed and guessed != mime:
+        raise ValueError("mime mismatch")

--- a/tests/test_discord_archiver.py
+++ b/tests/test_discord_archiver.py
@@ -65,8 +65,11 @@ def test_archive_file_records_manifest(monkeypatch, tmp_path):
     monkeypatch.setattr(api.uploader, "upload_file_sync", _fake_upload)
     res = api.archive_file(f, {"kind": "images", "visibility": "public"})
     assert res["channel_id"] == "123"
+    assert res["attachment_ids"] == ["2"]
     look = manifest.lookup(res["content_hash"])
     assert look is not None
+    assert look["attachment_ids"] == ["2"]
+    assert "final_size" in look["compression"]
     assert not f.exists()
 
 

--- a/tests/test_security_moderation.py
+++ b/tests/test_security_moderation.py
@@ -1,0 +1,21 @@
+from security.moderation import Moderation
+
+
+def test_moderation_allows_clean_text():
+    mod = Moderation(banned_terms=["bad"], action="redact")
+    res = mod.check("hello world")
+    assert res.action == "allow"
+    assert res.text == "hello world"
+
+
+def test_moderation_redacts_banned_term():
+    mod = Moderation(banned_terms=["bad"], action="redact")
+    res = mod.check("Bad word here")
+    assert res.action == "redact"
+    assert res.text == "[redacted] word here"
+
+
+def test_moderation_blocks_when_configured():
+    mod = Moderation(banned_terms=["bad"], action="block")
+    res = mod.check("bad")
+    assert res.action == "block"

--- a/tests/test_security_net_guard.py
+++ b/tests/test_security_net_guard.py
@@ -1,0 +1,21 @@
+from security.net_guard import is_safe_url
+
+
+def test_safe_and_unsafe_urls():
+    assert is_safe_url("https://example.com")
+    assert not is_safe_url("http://127.0.0.1")
+    assert not is_safe_url("file:///etc/passwd")
+    assert not is_safe_url("http://[::1]")
+    assert not is_safe_url("http://localhost")  # resolves to loopback
+    assert not is_safe_url("http://169.254.0.1")  # link-local
+    assert not is_safe_url("http://127.0.0.1\n")  # trailing whitespace stripped
+
+
+def test_domain_with_mixed_ips(monkeypatch):
+    from security import net_guard
+
+    def fake_resolve(host: str):
+        return ["93.184.216.34", "127.0.0.1"]  # example.com + loopback
+
+    monkeypatch.setattr(net_guard, "_resolve_host", fake_resolve)
+    assert not net_guard.is_safe_url("http://example.com")

--- a/tests/test_security_rate_limit.py
+++ b/tests/test_security_rate_limit.py
@@ -1,0 +1,18 @@
+import time
+from security.rate_limit import TokenBucket
+import pytest
+
+
+def test_token_bucket_behavior():
+    bucket = TokenBucket(rate=1, capacity=2)
+    assert bucket.allow("k")
+    assert bucket.allow("k")
+    assert not bucket.allow("k")
+    time.sleep(1.1)
+    assert bucket.allow("k")
+
+
+def test_token_bucket_rejects_non_positive_tokens():
+    bucket = TokenBucket(rate=1, capacity=1)
+    with pytest.raises(ValueError):
+        bucket.allow("k", tokens=0)

--- a/tests/test_security_rbac.py
+++ b/tests/test_security_rbac.py
@@ -1,0 +1,24 @@
+from security.rbac import RBAC
+import pytest
+
+
+def test_rbac_has_permission():
+    rbac = RBAC(role_permissions={"ops": {"ingest.backfill"}, "viewer": set()})
+    assert rbac.has_perm(["ops"], "ingest.backfill")
+    assert not rbac.has_perm(["viewer"], "ingest.backfill")
+    wildcard = RBAC(role_permissions={"admin": {"*"}})
+    assert wildcard.has_perm(["admin"], "anything")
+
+
+def test_rbac_require_decorator():
+    rbac = RBAC(role_permissions={"ops": {"ingest.backfill"}})
+
+    @rbac.require("ingest.backfill")
+    def do_work():
+        return "ok"
+
+    assert do_work(roles=["ops"]) == "ok"
+    with pytest.raises(PermissionError):
+        do_work(roles=["viewer"])
+    with pytest.raises(PermissionError):
+        do_work()  # missing roles defaults to empty

--- a/tests/test_security_secrets.py
+++ b/tests/test_security_secrets.py
@@ -1,0 +1,15 @@
+import os
+
+from security.secrets import get_secret, rotate_secret
+
+
+def test_get_secret_and_rotation(monkeypatch):
+    monkeypatch.setenv("EXAMPLE_TOKEN_V1", "alpha")
+    assert get_secret("EXAMPLE_TOKEN:v1") == "alpha"
+
+    monkeypatch.setenv("EXAMPLE_TOKEN_V1", "beta")
+    # cached value
+    assert get_secret("EXAMPLE_TOKEN:v1") == "alpha"
+
+    # rotate to refresh
+    assert rotate_secret("EXAMPLE_TOKEN:v1") == "beta"

--- a/tests/test_security_validate.py
+++ b/tests/test_security_validate.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import pytest
+
+from security import validate_url, validate_filename, validate_path, validate_mime
+
+
+def test_validate_url_rejects_private():
+    with pytest.raises(ValueError):
+        validate_url("http://127.0.0.1")
+
+
+def test_validate_filename_blocks_traversal():
+    with pytest.raises(ValueError):
+        validate_filename("../secret.txt")
+    assert validate_filename("safe.txt") == "safe.txt"
+
+
+def test_validate_path_prevents_escape(tmp_path: Path):
+    base = tmp_path / "base"
+    base.mkdir()
+    safe = validate_path("file.txt", base)
+    assert safe.parent == base
+    with pytest.raises(ValueError):
+        validate_path("../etc/passwd", base)
+
+
+def test_validate_mime_mismatch():
+    with pytest.raises(ValueError):
+        validate_mime("file.txt", "image/png")
+    # matching MIME should pass
+    validate_mime("file.txt", "text/plain")


### PR DESCRIPTION
## Summary
- record all Discord attachment IDs and compression parameters in the manifest for reliable rehydration and deduplication
- expose attachment_ids and compression stats from archive API and document canonical record fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8f0b3538832eb2166eb9f792b8b9