### PR TITLE
feat(security): add header helpers for webhook signing

### DIFF
--- a/docs/security/signing.md
+++ b/docs/security/signing.md
@@ -1,0 +1,25 @@
+# Webhook and Callback Signing
+
+The `security.signing` module provides helpers for attaching and verifying
+HMAC‑SHA256 signatures on arbitrary payloads. Signatures include a
+caller‑supplied timestamp and nonce to protect against replay.  Convenience
+helpers are provided to build and validate HTTP-style headers (`X-Signature`,
+`X-Timestamp`, `X-Nonce`).
+
+```python
+from security.signing import (
+    build_signature_headers,
+    verify_signature_headers,
+)
+
+payload = b"{\"status\": \"ok\"}"
+secret = "topsecret"
+headers = build_signature_headers(payload, secret)
+assert verify_signature_headers(payload, secret, headers)
+```
+
+Verification fails if the timestamp differs from the current time by more
+than the default 300 seconds, if the signature does not match the payload, or
+if the nonce is reused. A small in-memory cache of the last ~4k nonces is
+maintained to provide this replay protection; entries expire after the
+timestamp tolerance window.

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -11,6 +11,12 @@ from .validate import (
     validate_mime,
 )
 from .moderation import Moderation
+from .signing import (
+    sign_message,
+    verify_signature,
+    build_signature_headers,
+    verify_signature_headers,
+)
 
 __all__ = [
     "RBAC",
@@ -23,4 +29,8 @@ __all__ = [
     "validate_path",
     "validate_mime",
     "Moderation",
+    "sign_message",
+    "verify_signature",
+    "build_signature_headers",
+    "verify_signature_headers",
 ]

--- a/src/security/signing.py
+++ b/src/security/signing.py
@@ -1,0 +1,144 @@
+"""HMAC helpers for webhook and callback signing.
+
+The helpers here provide both low level primitives for generating and
+verifying signatures as well as convenience functions for HTTP style header
+handling.  Signatures are ``HMAC-SHA256`` over ``timestamp`` ``nonce`` and the
+payload bytes joined with a period.  The module also implements a bounded
+nonce cache to offer basic replay protection without unbounded memory use.
+"""
+
+from __future__ import annotations
+
+import hmac
+import hashlib
+import time
+import secrets
+from collections import OrderedDict
+from typing import Dict, Mapping
+
+
+# ``OrderedDict`` gives us a tiny LRU cache so replay protection does not grow
+# without bound.  Keys are nonces, values are the timestamp they were first
+# seen at.  Entries older than the verification tolerance are pruned on every
+# verify call and the cache size itself is capped at ``MAX_NONCES``.
+MAX_NONCES = 4096
+_seen_nonces: OrderedDict[str, int] = OrderedDict()
+
+
+def _prune_nonces(now: int, tolerance: int) -> None:
+    """Drop cached nonces that have aged past ``tolerance`` seconds or exceed
+    the ``MAX_NONCES`` limit."""
+    while _seen_nonces and (
+        now - next(iter(_seen_nonces.values())) > tolerance
+        or len(_seen_nonces) > MAX_NONCES
+    ):
+        _seen_nonces.popitem(last=False)
+
+
+def sign_message(payload: bytes, secret: str, timestamp: int, nonce: str) -> str:
+    """Return a hex digest signature for ``payload``.
+
+    The signature is ``HMAC-SHA256`` over ``timestamp`` ``nonce`` and ``payload``
+    bytes joined with a period. Callers must supply the same values to
+    :func:`verify_signature`.
+    """
+    base = f"{timestamp}.{nonce}.".encode() + payload
+    return hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+
+
+def build_signature_headers(
+    payload: bytes,
+    secret: str,
+    *,
+    timestamp: int | None = None,
+    nonce: str | None = None,
+) -> Dict[str, str]:
+    """Return signature headers for ``payload``.
+
+    Parameters
+    ----------
+    payload:
+        Request body bytes to sign.
+    secret:
+        Shared secret used to compute the HMAC.
+    timestamp, nonce:
+        Optional values to use instead of generating fresh ones.  ``timestamp``
+        defaults to ``time.time()`` and ``nonce`` is generated with
+        :func:`secrets.token_hex` when omitted.
+    """
+
+    ts = int(time.time()) if timestamp is None else int(timestamp)
+    n = nonce or secrets.token_hex(8)
+    sig = sign_message(payload, secret, ts, n)
+    return {"X-Signature": sig, "X-Timestamp": str(ts), "X-Nonce": n}
+
+
+def verify_signature(
+    payload: bytes,
+    secret: str,
+    signature: str,
+    timestamp: int,
+    nonce: str,
+    *,
+    tolerance: int = 300,
+) -> bool:
+    """Validate ``signature`` for ``payload`` and check freshness.
+
+    Parameters
+    ----------
+    payload:
+        Original payload bytes.
+    secret:
+        Shared secret used to compute the HMAC.
+    signature:
+        Hex digest produced by :func:`sign_message`.
+    timestamp:
+        Unix epoch seconds supplied by the caller when the signature was
+        generated. The signature is rejected if this differs from the current
+        time by more than ``tolerance`` seconds.
+    nonce:
+        Unique nonce provided by the caller. Reusing a nonce will cause
+        verification to fail.
+    tolerance:
+        Maximum age in seconds for a signature to be considered valid.
+    """
+
+    now = int(time.time())
+    _prune_nonces(now, tolerance)
+    if abs(now - int(timestamp)) > tolerance:
+        return False
+    expected = sign_message(payload, secret, int(timestamp), nonce)
+    if not hmac.compare_digest(expected, signature):
+        return False
+    # basic replay protection
+    if nonce in _seen_nonces:
+        return False
+    _seen_nonces[nonce] = now
+    _prune_nonces(now, tolerance)
+    return True
+
+
+def verify_signature_headers(
+    payload: bytes,
+    secret: str,
+    headers: Mapping[str, str],
+    *,
+    signature_header: str = "X-Signature",
+    timestamp_header: str = "X-Timestamp",
+    nonce_header: str = "X-Nonce",
+    tolerance: int = 300,
+) -> bool:
+    """Validate signature contained in HTTP-style ``headers``.
+
+    The helper expects the same header names produced by
+    :func:`build_signature_headers` but they can be overridden.
+    Missing headers cause the check to fail.
+    """
+
+    try:
+        signature = headers[signature_header]
+        timestamp = int(headers[timestamp_header])
+        nonce = headers[nonce_header]
+    except KeyError:
+        return False
+    return verify_signature(payload, secret, signature, timestamp, nonce, tolerance=tolerance)

--- a/tests/test_security_signing.py
+++ b/tests/test_security_signing.py
@@ -1,0 +1,56 @@
+import time
+import security.signing as signing
+from security.signing import (
+    sign_message,
+    verify_signature,
+    build_signature_headers,
+    verify_signature_headers,
+)
+
+def test_sign_and_verify():
+    secret = "s3cr3t"
+    payload = b"payload"
+    ts = int(time.time())
+    nonce = "abc"
+    sig = sign_message(payload, secret, ts, nonce)
+    assert verify_signature(payload, secret, sig, ts, nonce)
+
+def test_replay_and_tamper():
+    secret = "s3cr3t"
+    payload = b"data"
+    ts = int(time.time())
+    nonce = "n1"
+    sig = sign_message(payload, secret, ts, nonce)
+    assert verify_signature(payload, secret, sig, ts, nonce)
+    assert not verify_signature(payload, secret, sig, ts, nonce)
+    ts2 = int(time.time())
+    nonce2 = "n2"
+    sig2 = sign_message(payload, secret, ts2, nonce2)
+    assert not verify_signature(b"other", secret, sig2, ts2, nonce2)
+    old_ts = ts2 - 1000
+    sig3 = sign_message(payload, secret, old_ts, "n3")
+    assert not verify_signature(payload, secret, sig3, old_ts, "n3", tolerance=10)
+
+
+def test_header_helpers():
+    secret = "s3cr3t"
+    payload = b"data"
+    headers = build_signature_headers(payload, secret)
+    assert verify_signature_headers(payload, secret, headers)
+    # missing header -> fail
+    bad = headers.copy()
+    bad.pop("X-Signature")
+    assert not verify_signature_headers(payload, secret, bad)
+
+
+def test_nonce_cache_bounded(monkeypatch):
+    secret = "s3cr3t"
+    payload = b"x"
+    signing._seen_nonces.clear()
+    monkeypatch.setattr(signing, "MAX_NONCES", 3)
+    base_ts = int(time.time())
+    for i in range(5):
+        nonce = f"n{i}"
+        sig = sign_message(payload, secret, base_ts + i, nonce)
+        assert verify_signature(payload, secret, sig, base_ts + i, nonce)
+    assert len(signing._seen_nonces) <= 3


### PR DESCRIPTION
## Summary
- add helper functions to build and verify HMAC-SHA256 headers
- cap replay-protection nonce cache and document its limits
- cover helpers and cache behaviour with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae9d05769c832ebc67162b26252cbd